### PR TITLE
[Feat] 이메일 검증 항목 추가

### DIFF
--- a/src/main/java/sheetplus/checkings/business/email/service/EmailService.java
+++ b/src/main/java/sheetplus/checkings/business/email/service/EmailService.java
@@ -91,10 +91,19 @@ public class EmailService {
         String emailDomain = email.
                 substring(email
                         .lastIndexOf(SEPARATOR)+1);
+        String emailId = email.substring(0, email.lastIndexOf(SEPARATOR));
 
         if(!VALIDATE_EMAIL_DOMAINS.contains(emailDomain)){
             throw new ApiException(UNIVERSITY_EMAIL_NOT_VALID);
         }
+        if(emailId.length() >= 65){
+            throw new ApiException(EMAIL_LENGTH_TOO_LONG);
+        }
+        if(!emailId.matches("^[a-zA-Z0-9]+$")){
+            throw new ApiException(EMAIL_NOT_FORMAT);
+        }
+
+
     }
 
     @Transactional

--- a/src/main/java/sheetplus/checkings/exception/error/ApiError.java
+++ b/src/main/java/sheetplus/checkings/exception/error/ApiError.java
@@ -17,6 +17,8 @@ public enum ApiError implements ErrorCodeIfs {
     TEMPORARY_NOT_FOUND(404, "임시멤버정보를 찾을 수 없음"),
     TEMPORARY_NOT_VALID_CODE(403, "인증된 인증코드가 아닙니다."),
     UNIVERSITY_EMAIL_NOT_VALID(403, "학교 이메일이 아닙니다."),
+    EMAIL_LENGTH_TOO_LONG(404, "이메일 ID 길이가 초과되었습니다. 확인해주세요"),
+    EMAIL_NOT_FORMAT(404, "이메일 형식이 일치하지 않습니다. 확인해주세요"),
     EMAIL_NOT_AUTHENTICATE(403, "인증된 이메일이 아닙니다."),
     TOKEN_NOT_VALID(403, "유효한 토큰이 아닙니다."),
     SUPER_ADMIN_REGISTER_BLOCK(403, "SUPER_ADMIN 회원가입은 개발자에게 요청하세요"),


### PR DESCRIPTION
- [x] 이메일 검증 항목 추가


# 검증 대상
- 이메일 ID 길이 최대 64자
- 이메일 ID 정규표현식 검증

# 반송/수신차단 관련
학교 이메일 서버에서 반송메일을 보내거나 수신 차단 관련 응답을 주지 않음.
Mailgun에서 이메일 발송 성공으로만 뜨기 때문에 학교 이메일 발송으로 한정된 현재 프로젝트에서,
도메인 평판 악영향은 크게 신경 안 써도 될 것으로 예상됨

