### PR TITLE
[Feat] 외부 API 요청 재시도 기능 / 스케줄러 작업 재실행 정책 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'com.mailgun:mailgun-java:1.1.3'
 	implementation 'org.springframework.boot:spring-boot-starter-quartz'
-
+	implementation 'org.springframework.retry:spring-retry:2.0.11'
 
 	// Firebase Admin SDK
 	implementation 'com.google.firebase:firebase-admin:9.4.2'

--- a/src/main/java/sheetplus/checkings/CheckingApplication.java
+++ b/src/main/java/sheetplus/checkings/CheckingApplication.java
@@ -3,8 +3,10 @@ package sheetplus.checkings;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
 
+@EnableRetry
 @EnableJpaAuditing
 @SpringBootApplication
 public class CheckingApplication {

--- a/src/main/java/sheetplus/checkings/business/notifications/service/EventSchedulerService.java
+++ b/src/main/java/sheetplus/checkings/business/notifications/service/EventSchedulerService.java
@@ -240,6 +240,11 @@ public class EventSchedulerService {
                     .startAt(Date.from(notificationTimeBefore
                             .atZone(ZoneId.systemDefault())
                             .toInstant()))
+                    .withSchedule(
+                            SimpleScheduleBuilder
+                                    .simpleSchedule()
+                                    .withMisfireHandlingInstructionFireNow()
+                    )
                     .build();
 
             // 3번 작업 시작 시점 알림
@@ -257,6 +262,11 @@ public class EventSchedulerService {
                     .startAt(Date.from(startTime
                             .atZone(ZoneId.systemDefault())
                             .toInstant()))
+                    .withSchedule(
+                            SimpleScheduleBuilder
+                                    .simpleSchedule()
+                                    .withMisfireHandlingInstructionFireNow()
+                    )
                     .build();
 
             // 4번 작업

--- a/src/main/java/sheetplus/checkings/business/notifications/service/NotificationService.java
+++ b/src/main/java/sheetplus/checkings/business/notifications/service/NotificationService.java
@@ -1,13 +1,19 @@
 package sheetplus.checkings.business.notifications.service;
 
+import com.google.firebase.ErrorCode;
+import com.google.firebase.FirebaseException;
 import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import sheetplus.checkings.domain.enums.SendingType;
+import sheetplus.checkings.exception.exceptionMethod.CustomFirebaseMessagingException;
 
 
 @Service
@@ -43,7 +49,7 @@ public class NotificationService implements Job {
                         + jobDetail.getJobDataMap().get("contestId"))
                 .build();
         try {
-            String response = fcm.send(message);
+            String response = fcmSend(message);
             log.info("메세지 발송 성공: {}", response);
             if(title.equals("이벤트 시작 10분 전 알림")){
                 eventSchedulerService.sendStatusChange((Long) jobDetail.getJobDataMap().get("eventId"),
@@ -55,8 +61,29 @@ public class NotificationService implements Job {
                         SendingType.EVENT_START_NOW);
             }
 
-        } catch (FirebaseMessagingException e) {
+        } catch (CustomFirebaseMessagingException | FirebaseException e) {
+            log.error("토픽구독과정 오류 발생: {}", e.getMessage());
             throw new RuntimeException(e);
+        }
+    }
+
+    @Retryable(
+            retryFor = {CustomFirebaseMessagingException.class},
+            exceptionExpression = "errorCode == ErrorCode.UNAVAILABLE || errorCode == ErrorCode.INTERNAL",
+            maxAttempts = 5,
+            backoff = @Backoff(
+                    random = true,
+                    delay = 10000,
+                    multiplier = 3,
+                    maxDelay = 600000
+            )
+    )
+    public String fcmSend(Message message) throws FirebaseMessagingException {
+        try{
+            return fcm.send(message);
+        }catch (FirebaseMessagingException e) {
+            log.error("예외 발생: {}", e.getErrorCode());
+            throw new CustomFirebaseMessagingException(e);
         }
     }
 

--- a/src/main/java/sheetplus/checkings/business/notifications/service/NotificationService.java
+++ b/src/main/java/sheetplus/checkings/business/notifications/service/NotificationService.java
@@ -1,11 +1,9 @@
 package sheetplus.checkings.business.notifications.service;
 
-import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseException;
 import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;

--- a/src/main/java/sheetplus/checkings/config/SchedulerConfig.java
+++ b/src/main/java/sheetplus/checkings/config/SchedulerConfig.java
@@ -22,7 +22,8 @@ public class SchedulerConfig{
         return TriggerBuilder.newTrigger()
                 .forJob(eventScheduleJob())
                 .withIdentity("eventNotificationTrigger", "dailyEventNotificationTrigger")
-                .withSchedule(CronScheduleBuilder.dailyAtHourAndMinute(0, 30))
+                .withSchedule(CronScheduleBuilder.dailyAtHourAndMinute(0, 30)
+                        .withMisfireHandlingInstructionFireAndProceed())
                 .startNow()
                 .build();
     }

--- a/src/main/java/sheetplus/checkings/exception/exceptionMethod/CustomFirebaseMessagingException.java
+++ b/src/main/java/sheetplus/checkings/exception/exceptionMethod/CustomFirebaseMessagingException.java
@@ -1,0 +1,23 @@
+package sheetplus.checkings.exception.exceptionMethod;
+
+
+import com.google.firebase.ErrorCode;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public class CustomFirebaseMessagingException extends RuntimeException{
+    public final ErrorCode errorCode;
+
+    public CustomFirebaseMessagingException(FirebaseMessagingException e) {
+        this.errorCode = e.getErrorCode();
+        log.error("설정 에러코드: {}", errorCode);
+    }
+
+    public CustomFirebaseMessagingException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+}


### PR DESCRIPTION
- [X] FCM 웹 푸시알림 발송 실패 시, 재시도(Retry) 로직 개발 
- [x] FCM 구독과정 실패 시, 재시도(Retry) 로직 개발
- [x] 스케줄러 실패(Misfire)시, 재실행 정책 설정

## 재시도 로직 상세
### FCM 웹 푸시알림 발송 실패
- UNAVAILABLE(FCM 서버 일시적인 문제), INTERNAL(FCM 서버 내부 오류) 예외상황만 재시도 요청
- 최대 요청횟수: 5회
- Jitter 적용여부: 적용
- 재요청 delay: 10초 (FCM 공식 문서에서 추천하는 재요청 delay로 설정)
- 지수백오프 간격: 3
- 최대 delay: 10분

### FCM 구독과정 실패
- {ExecutionException.class, InterruptedException.class} 비동기 작업 실패 시, 재시도 요청
- 최대 요청횟수: 5회
- Jitter 적용여부: 적용
- 재요청 delay: 10초 (FCM 공식 문서에서 추천하는 재요청 delay로 설정)
- 지수백오프 간격: 3
- 최대 delay: 10분


## Misfire 정책 상세
### Cron 스케줄링 작업
- Misfire 발생 시, 즉시 재시도

### Event StartTime 스케줄링 작업
- Misfire 발생 시, 즉시 재시도

### Misfire 감지 조건
- 예정된 시간 이후, 10초 내로 실행하지 않을 경우, Misfire 발생
