### PR TITLE
[Feat] N+1 문제 해결을 위한 설정 추가 및 쿼리 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ![백엔드아키텍처](https://github.com/user-attachments/assets/8d3fe22f-0357-478c-8181-4130e73adeed)
 
 ## DB ERD
-![eventSending 추가 erd](https://github.com/user-attachments/assets/c8be2fd7-7ec8-4d73-8d65-816a6cc6aa26)
+![새로운ERD](https://github.com/user-attachments/assets/a9d6c562-afd9-4ac4-85f4-cb7d57240e98)
 
 
 ## 주요기능

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminHomeResponseDto;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
 import sheetplus.checkings.domain.member.dto.MemberDto.MemberInfoResponseDto;
 import sheetplus.checkings.business.page.admin.service.AdminPageService;
 
@@ -39,6 +40,13 @@ public class AdminPageController implements AdminPageControllerSpec{
     ){
         return ResponseEntity.ok(adminPageService
                 .readDrawMemberList(contestId, PageRequest.of(offset-1, limit)));
+    }
+
+    @GetMapping("/contests/{contest}/v1")
+    public ResponseEntity<List<ContestInfoWithCounts>> readContestInfos(
+    ){
+        return ResponseEntity.ok(adminPageService
+                .readContestInfoWithCounts());
     }
 
     /**

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminHomeResponseDto;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
 import sheetplus.checkings.domain.member.dto.MemberDto.MemberInfoResponseDto;
 import sheetplus.checkings.exception.error.ErrorResponse;
 
@@ -80,4 +81,26 @@ public interface AdminPageControllerSpec {
             Integer offset,
             @Parameter(description = "페이지당 조회할 데이터 개수", example = "1")
             Integer limit);
+
+
+    @Operation(summary = "Admin-Page ContestInfo with Counts", description = "Admin-Page Contest 정보 조회 화면")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Contest 정보 조회를 성공했습니다.",
+                    content = @Content(array = @ArraySchema(schema =
+                    @Schema(implementation = MemberInfoResponseDto.class)),
+                            mediaType = "application/json"),
+                    headers = {@Header(name = "etag",
+                            description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
+                            @Header(name = "Cache-Control",
+                                    description = "클라이언트 캐시 사용, 캐싱 최대유효시간 1시간, 유효시간 지난 후에는 반드시 서버로 재요청하세요")}),
+            @ApiResponse(responseCode = "304", description = "캐시 데이터의 변경사항이 없습니다. 로컬 캐시 데이터를 사용하세요",
+                    content = @Content (mediaType = "None")),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰이 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json"))
+    })
+    ResponseEntity<List<ContestInfoWithCounts>> readContestInfos();
 }

--- a/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryResponseDto;
+import sheetplus.checkings.domain.enums.ContestCons;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 
 import java.time.LocalDateTime;
@@ -31,7 +32,7 @@ public class AdminPageDto {
     @Getter
     @Builder
     @NoArgsConstructor @AllArgsConstructor
-    @Schema(description = "Email Response Dto", contentMediaType = "application/json")
+    @Schema(description = "Admin Home Response Dto", contentMediaType = "application/json")
     public static class AdminHomeResponseDto{
         // 좌상
         @Schema(description = "Member 수",
@@ -105,5 +106,31 @@ public class AdminPageDto {
         private List<EntryResponseDto> entryPageable;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "Contest Info With Counts", contentMediaType = "application/json")
+    public static class ContestInfoWithCounts{
+        @Schema(description = "이벤트 명",
+                example = "contestName", type = "String")
+        private String name;
+        @Schema(description = "Contest 시작시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime startDate;
+        @Schema(description = "Contest 종료시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime endDate;
+
+        @Schema(description = "대회 상태",
+                example = "EVENT_PROGRESS", type = "enum", enumAsRef = true)
+        private ContestCons cons;
+        @Schema(description = "이벤트 개수",
+                example = "50", type = "Integer")
+        private Integer eventCounts;
+        @Schema(description = "작품 개수",
+                example = "50", type = "Integer")
+        private Integer entryCounts;
+    }
 
 }

--- a/src/main/java/sheetplus/checkings/business/page/admin/service/AdminPageService.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/service/AdminPageService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminHomeResponseDto;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
 import sheetplus.checkings.domain.contest.entity.Contest;
 import sheetplus.checkings.domain.event.entity.Event;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryInfoResponseDto;
@@ -80,9 +81,20 @@ public class AdminPageService {
         }
 
 
-
         EntryInfoResponseDto entryInfoResponseDto = entryRepository.entryInfoCounts();
-        List<EntryResponseDto> entryList = entryRepository.getEntry();
+        List<EntryResponseDto> entryList = contest.getEntries().stream()
+                .map(p -> EntryResponseDto.builder()
+                        .id(p.getId())
+                        .entryType(p.getEntryType().getMessage())
+                        .professorName(p.getProfessorName())
+                        .major(p.getMajor())
+                        .teamNumber(p.getTeamNumber())
+                        .leaderName(p.getLeaderName())
+                        .location(p.getLocation())
+                        .building(p.getBuilding())
+                        .name(p.getName())
+                        .build())
+                .toList();
 
 
         return AdminHomeResponseDto.builder()
@@ -126,11 +138,18 @@ public class AdminPageService {
     }
 
 
+    @Transactional(readOnly = true)
     public List<MemberInfoResponseDto> readDrawMemberList(Long contestId, Pageable pageable){
         Contest contest = contestRepository.findById(contestId)
                 .orElseThrow(() -> new ApiException(CONTEST_NOT_FOUND));
         return participateContestStateRepository
                 .drawMemberInfoRead(contest.getId(), pageable);
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<ContestInfoWithCounts> readContestInfoWithCounts(){
+        return contestRepository.findContestInfoWithCounts();
     }
 
 

--- a/src/main/java/sheetplus/checkings/business/page/student/service/StudentPageService.java
+++ b/src/main/java/sheetplus/checkings/business/page/student/service/StudentPageService.java
@@ -35,21 +35,15 @@ public class StudentPageService {
 
     @Transactional(readOnly = true)
     public StudentHomePageResponseDto readStudentHomePage(String token, Long contestId) {
-        Member member = memberRepository.findById(jwtUtil.getMemberId(token))
+        Member member = memberRepository.findByIdAndWithGraph(jwtUtil.getMemberId(token))
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
-        Integer eventCounts = 0;
-        if(member.getMemberParticipateContestStates() != null){
-            eventCounts = member.getMemberParticipateContestStates()
-                    .getEventsCount();
-        }
-
-
+        Integer count = participateContestStateRepository.participateCounts(member.getId(), contestId);
 
 
         return StudentHomePageResponseDto.builder()
                 .studentName(member.getName())
                 .studentMajor(member.getMajor())
-                .eventCounts(eventCounts.toString())
+                .eventCounts(Integer.toString(count))
                 .events(contestRepository.findNowAfterEvents(
                         contestId))
                 .build();

--- a/src/main/java/sheetplus/checkings/domain/contest/entity/Contest.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/entity/Contest.java
@@ -43,10 +43,6 @@ public class Contest {
     @Column(nullable = false)
     private ContestCons cons;
 
-    @OneToMany(mappedBy = "contestParticipateContestState", cascade = CascadeType.REMOVE)
-    @Builder.Default
-    private List<ParticipateContest> participateContests = new ArrayList<>();
-
     @OneToMany(mappedBy = "entryContest", orphanRemoval = true)
     @Builder.Default
     private List<Entry> entries = new ArrayList<>();

--- a/src/main/java/sheetplus/checkings/domain/contest/entity/Contest.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/entity/Contest.java
@@ -43,6 +43,9 @@ public class Contest {
     @Column(nullable = false)
     private ContestCons cons;
 
+    @OneToOne(mappedBy = "contestParticipateContestState")
+    private ParticipateContest participateContestStateContest;
+
     @OneToMany(mappedBy = "entryContest", orphanRemoval = true)
     @Builder.Default
     private List<Entry> entries = new ArrayList<>();

--- a/src/main/java/sheetplus/checkings/domain/contest/entity/Contest.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/entity/Contest.java
@@ -4,6 +4,7 @@ package sheetplus.checkings.domain.contest.entity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import sheetplus.checkings.domain.contest.dto.ContestDto.ContestRequestDto;
 import sheetplus.checkings.domain.draw.entity.Draw;
 import sheetplus.checkings.domain.entry.entity.Entry;
@@ -46,10 +47,12 @@ public class Contest {
     @OneToOne(mappedBy = "contestParticipateContestState")
     private ParticipateContest participateContestStateContest;
 
+    @BatchSize(size = 1000)
     @OneToMany(mappedBy = "entryContest", orphanRemoval = true)
     @Builder.Default
     private List<Entry> entries = new ArrayList<>();
 
+    @BatchSize(size = 1000)
     @OneToMany(mappedBy = "eventContest", orphanRemoval = true)
     @Builder.Default
     private List<Event> events = new ArrayList<>();

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
@@ -1,6 +1,7 @@
 package sheetplus.checkings.domain.contest.repository;
 
 import org.springframework.data.domain.Pageable;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.enums.EventCategory;
 
@@ -11,5 +12,6 @@ public interface ContestRepositoryCustom {
     List<EventResponseDto> findNowAfterEvents(Long contestId);
     List<EventResponseDto> findTodayEvents(Long contestId, Pageable pageable);
     List<EventResponseDto> findParticipateEvents(Long contestId, List<EventCategory> category);
+    List<ContestInfoWithCounts> findContestInfoWithCounts();
 
 }

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.contest.entity.Contest;
 import sheetplus.checkings.domain.event.entity.Event;
@@ -107,5 +108,22 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
         }
 
         return getEventResponseDtos(events);
+    }
+
+    @Override
+    public List<ContestInfoWithCounts> findContestInfoWithCounts() {
+        return queryFactory.selectFrom(contest)
+                .leftJoin(contest.participateContestStateContest, participateContest)
+                .fetchJoin()
+                .fetch().stream()
+                .map(p -> ContestInfoWithCounts.builder()
+                        .name(p.getName())
+                        .startDate(p.getStartDate())
+                        .endDate(p.getEndDate())
+                        .cons(p.getCons())
+                        .eventCounts(p.getEvents().size())
+                        .entryCounts(p.getEntries().size())
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static sheetplus.checkings.domain.contest.entity.QContest.contest;
 import static sheetplus.checkings.domain.event.entity.QEvent.event;
+import static sheetplus.checkings.domain.participatecontest.entity.QParticipateContest.participateContest;
 import static sheetplus.checkings.exception.error.ApiError.CONTEST_NOT_FOUND;
 
 @Slf4j
@@ -27,6 +28,8 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
     @Override
     public List<EventResponseDto> findTodayEvents(Long contestId, Pageable pageable) {
         Contest findContest = queryFactory.selectFrom(contest)
+                .join(contest.participateContestStateContest, participateContest)
+                .fetchJoin()
                 .where(contest.id.eq(contestId))
                 .fetchFirst();
 

--- a/src/main/java/sheetplus/checkings/domain/draw/entity/Draw.java
+++ b/src/main/java/sheetplus/checkings/domain/draw/entity/Draw.java
@@ -30,8 +30,7 @@ public class Draw {
     @JoinColumn(name = "contest_id")
     private Contest drawContest;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @OneToOne(mappedBy = "memberDraw", cascade = CascadeType.REMOVE)
     private Member drawMember;
 
     public void setContestDraw(Contest contestDraw) {

--- a/src/main/java/sheetplus/checkings/domain/entry/repository/EntryRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/entry/repository/EntryRepositoryCustomImpl.java
@@ -63,6 +63,7 @@ public class EntryRepositoryCustomImpl implements EntryRepositoryCustom{
                         .id(p.getId())
                         .entryType(p.getEntryType().getMessage())
                         .professorName(p.getProfessorName())
+                        .major(p.getMajor())
                         .teamNumber(p.getTeamNumber())
                         .leaderName(p.getLeaderName())
                         .location(p.getLocation())

--- a/src/main/java/sheetplus/checkings/domain/event/entity/Event.java
+++ b/src/main/java/sheetplus/checkings/domain/event/entity/Event.java
@@ -68,6 +68,7 @@ public class Event {
     private Contest eventContest;
 
     @OneToMany(mappedBy = "eventSendingEvent", cascade = CascadeType.REMOVE)
+    @Builder.Default
     private List<EventSending> eventSending = new ArrayList<>();
 
 

--- a/src/main/java/sheetplus/checkings/domain/member/entity/Member.java
+++ b/src/main/java/sheetplus/checkings/domain/member/entity/Member.java
@@ -18,6 +18,15 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @ToString
+@NamedEntityGraph(
+        name = "member.withParticipateContest",
+        attributeNodes ={
+            @NamedAttributeNode(value = "memberParticipateContestStates", subgraph = "participateContest.withContest")
+        },
+        subgraphs = @NamedSubgraph(name = "participateContest.withContest", attributeNodes = {
+                @NamedAttributeNode("contestParticipateContestState")
+        })
+)
 public class Member {
 
     @Id
@@ -43,10 +52,12 @@ public class Member {
     @Column(nullable = false)
     private MemberType memberType;
 
-    @OneToOne(mappedBy = "memberParticipateContestState", cascade = CascadeType.REMOVE)
-    private ParticipateContest memberParticipateContestStates;
+    @OneToMany(mappedBy = "memberParticipateContestState", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<ParticipateContest> memberParticipateContestStates = new ArrayList<>();
 
-    @OneToOne(mappedBy = "drawMember", cascade = CascadeType.REMOVE)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "draw_id")
     private Draw memberDraw;
 
     @OneToMany(mappedBy = "favoriteMember", orphanRemoval = true)
@@ -58,14 +69,6 @@ public class Member {
         this.name = memberUpdateRequestDto.getName();
         this.major = memberUpdateRequestDto.getMajor();
         this.studentId = memberUpdateRequestDto.getStudentId();
-    }
-
-    public void setMemberParticipateContestStates(
-            ParticipateContest memberParticipateContestStates) {
-        this.memberParticipateContestStates = memberParticipateContestStates;
-        if(memberParticipateContestStates.getMemberParticipateContestState() != this){
-            memberParticipateContestStates.setMemberParticipateContestStates(this);
-        }
     }
 
     public void setDrawMember(Draw draw){

--- a/src/main/java/sheetplus/checkings/domain/member/repository/MemberRepository.java
+++ b/src/main/java/sheetplus/checkings/domain/member/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package sheetplus.checkings.domain.member.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import sheetplus.checkings.domain.member.entity.Member;
 
 import java.util.Optional;
@@ -8,4 +10,9 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberByUniversityEmail(String email);
+
+    @EntityGraph(value = "member.withParticipateContest", type = EntityGraph.EntityGraphType.LOAD)
+    @Query("select distinct c from Member c")
+    Optional<Member> findByIdAndWithGraph(Long id);
+
 }

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/entity/ParticipateContest.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/entity/ParticipateContest.java
@@ -50,11 +50,11 @@ public class ParticipateContest {
     @Column(nullable = false)
     private MeritType meritType;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id")
     private Member memberParticipateContestState;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne
     @JoinColumn(name = "contest_id")
     private Contest contestParticipateContestState;
 
@@ -70,14 +70,11 @@ public class ParticipateContest {
 
     public void setMemberParticipateContestStates(Member member){
         this.memberParticipateContestState = member;
-        if(this.memberParticipateContestState.getMemberParticipateContestStates() != this){
-            member.setMemberParticipateContestStates(this);
-        }
+        member.getMemberParticipateContestStates().add(this);
     }
 
     public void setContestParticipateContestStates(Contest contest){
         this.contestParticipateContestState = contest;
-        contest.getParticipateContests().add(this);
     }
 
     public void addCounts(){

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustom.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustom.java
@@ -11,7 +11,7 @@ public interface ParticipateContestStateRepositoryCustom {
     void targetUpdates(int condition);
     ParticipateInfoResponseDto participateContestCounts(Long id);
     List<MemberInfoResponseDto> drawMemberInfoRead(Long contestId, Pageable pageable);
-
+    Integer participateCounts(Long memberId, Long contestId);
 
     /**
      *

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
@@ -101,4 +101,13 @@ public class ParticipateContestStateRepositoryCustomImpl implements ParticipateC
                         .build())
                 .toList();
     }
+
+    @Override
+    public Integer participateCounts(Long memberId, Long contestId) {
+        return queryFactory.select(participateContest.eventsCount)
+                .from(participateContest)
+                .where(participateContest.memberParticipateContestState.id.eq(memberId)
+                        .and(participateContest.contestParticipateContestState.id.eq(contestId)))
+                .fetchFirst();
+    }
 }


### PR DESCRIPTION
- [x] Member-ParticipateContest 연관관계 변경
- [x] Contest-ParticipateContest 연관관계 변경
- [X] EntityGraph설정 추가 및 조회 쿼리 횟수 축소 (3회 -> 1회)
- [X] 대회별 참여 행사수 조회 쿼리 개선
- [X] Contest- ParticipateContest간 Fetch Join 설정
- [X] Contest 정보 + Event 개수 + Entry 개수 조회 기능 개발
- [X] N+1 문제 방지를 위해 Event,Entry 연관관계에 @BatchSize 지정
- [X] README.MD ERD 업데이트
