### PR TITLE
[Refactor] 페이지에 의존하는 API 분리 및 쿼리 최적화 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ![백엔드아키텍처](https://github.com/user-attachments/assets/8d3fe22f-0357-478c-8181-4130e73adeed)
 
 ## DB ERD
-![새로운 ERD](https://github.com/user-attachments/assets/cf6332a4-50a2-4de0-a867-42ab9e140fb7)
+![erd추가](https://github.com/user-attachments/assets/16e109d6-99c8-4383-8dd3-b9b03a1c02b5)
 
 ## 주요기능
 ### 요약

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
@@ -6,8 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminHomeResponseDto;
-import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.*;
 import sheetplus.checkings.domain.member.dto.MemberDto.MemberInfoResponseDto;
 import sheetplus.checkings.business.page.admin.service.AdminPageService;
 
@@ -21,12 +20,38 @@ public class AdminPageController implements AdminPageControllerSpec{
 
     private final AdminPageService adminPageService;
 
-    @GetMapping("/contests/{contest}/home/v1")
-    public ResponseEntity<AdminHomeResponseDto> readAdminHome(
+    @GetMapping("/contests/{contest}/homes/stamp-stat/v2")
+    public ResponseEntity<AdminStampStatsDto> readAdminHomeStampStats(
             @PathVariable(name = "contest") Long contestId){
-        AdminHomeResponseDto adminHomeResponseDto =
-                adminPageService.adminHomeRead(contestId);
-        return ResponseEntity.ok(adminHomeResponseDto);
+
+        return ResponseEntity
+                .ok(adminPageService
+                        .stampStats(contestId));
+    }
+
+    @GetMapping("/contests/{contest}/homes/contest-stat/v2")
+    public ResponseEntity<AdminContestStatsDto> readAdminHomeContestStats(
+            @PathVariable(name = "contest") Long contestId){
+        return ResponseEntity
+                .ok(adminPageService
+                        .contestStatsDto(contestId));
+    }
+
+    @GetMapping("/contests/{contest}/homes/event-stat/v2")
+    public ResponseEntity<AdminEventStatsDto> readAdminHomeEventStats(
+            @PathVariable(name = "contest") Long contestId){
+
+        return ResponseEntity
+                .ok(adminPageService
+                        .eventStatsDto(contestId));
+    }
+
+    @GetMapping("/contests/{contest}/homes/entry-stat/v2")
+    public ResponseEntity<AdminEntryStatsDto> readAdminHomeEntryStats(
+            @PathVariable(name = "contest") Long contestId){
+        return ResponseEntity
+                .ok(adminPageService
+                        .entryStatsDto(contestId));
     }
 
 

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
@@ -65,7 +65,7 @@ public class AdminPageController implements AdminPageControllerSpec{
             Integer limit){
         return ResponseEntity
                 .ok(adminPageService
-                        .entryStatsDto(contestId, PageRequest.of(offset, limit)));
+                        .entryStatsDto(contestId, PageRequest.of(offset-1, limit)));
     }
 
 

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageController.java
@@ -1,6 +1,8 @@
 package sheetplus.checkings.business.page.admin.controller;
 
 
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -39,28 +41,42 @@ public class AdminPageController implements AdminPageControllerSpec{
 
     @GetMapping("/contests/{contest}/homes/event-stat/v2")
     public ResponseEntity<AdminEventStatsDto> readAdminHomeEventStats(
-            @PathVariable(name = "contest") Long contestId){
+            @PathVariable(name = "contest") Long contestId,
+            @NotNull(message = "offset의 null값은 허용하지 않습니다.")
+            @Parameter(description = "조회할 페이지 번호", example = "1")
+            Integer offset,
+            @NotNull(message = "limit의 null값은 허용하지 않습니다.")
+            @Parameter(description = "페이지당 조회할 데이터 개수", example = "1")
+            Integer limit){
 
         return ResponseEntity
                 .ok(adminPageService
-                        .eventStatsDto(contestId));
+                        .eventStatsDto(contestId, PageRequest.of(offset-1, limit)));
     }
 
     @GetMapping("/contests/{contest}/homes/entry-stat/v2")
     public ResponseEntity<AdminEntryStatsDto> readAdminHomeEntryStats(
-            @PathVariable(name = "contest") Long contestId){
+            @PathVariable(name = "contest") Long contestId,
+            @NotNull(message = "offset의 null값은 허용하지 않습니다.")
+            @RequestParam(value = "offset")
+            Integer offset,
+            @NotNull(message = "limit의 null값은 허용하지 않습니다.")
+            @RequestParam(value = "limit")
+            Integer limit){
         return ResponseEntity
                 .ok(adminPageService
-                        .entryStatsDto(contestId));
+                        .entryStatsDto(contestId, PageRequest.of(offset, limit)));
     }
 
 
     @GetMapping("/contests/{contest}/draw/members/v1")
     public ResponseEntity<List<MemberInfoResponseDto>> readDrawMemberList(
             @PathVariable("contest") Long contestId,
-            @RequestParam(value = "offset", required = false)
+            @NotNull(message = "offset의 null값은 허용하지 않습니다.")
+            @RequestParam(value = "offset")
             Integer offset,
-            @RequestParam(value = "limit", required = false)
+            @NotNull(message = "limit의 null값은 허용하지 않습니다.")
+            @RequestParam(value = "limit")
             Integer limit
     ){
         return ResponseEntity.ok(adminPageService

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.*;
 import sheetplus.checkings.domain.member.dto.MemberDto.MemberInfoResponseDto;
@@ -104,7 +105,13 @@ public interface AdminPageControllerSpec {
     })
     ResponseEntity<AdminEventStatsDto> readAdminHomeEventStats(
             @Parameter(description = "Contest PK", example = "1")
-            Long contestId);
+            Long contestId,
+            @NotNull(message = "offset의 null값은 허용하지 않습니다.")
+            @Parameter(description = "조회할 페이지 번호", example = "1")
+            Integer offset,
+            @NotNull(message = "limit의 null값은 허용하지 않습니다.")
+            @Parameter(description = "페이지당 조회할 데이터 개수", example = "1")
+            Integer limit);
 
     @Operation(summary = "어드민 홈페이지 - Entry 통계", description = "어드민 홈페이지 - Entry 통계 데이터를 조회합니다")
     @ApiResponses(value = {
@@ -133,7 +140,13 @@ public interface AdminPageControllerSpec {
     })
     ResponseEntity<AdminEntryStatsDto> readAdminHomeEntryStats(
             @Parameter(description = "Contest PK", example = "1")
-            Long contestId);
+            Long contestId,
+            @NotNull(message = "offset의 null값은 허용하지 않습니다.")
+            @Parameter(description = "조회할 페이지 번호", example = "1")
+            Integer offset,
+            @NotNull(message = "limit의 null값은 허용하지 않습니다.")
+            @Parameter(description = "페이지당 조회할 데이터 개수", example = "1")
+            Integer limit);
 
     @Operation(summary = "Admin-Page Draw-Member", description = "Admin-Page Draw-Member 조회 화면")
     @ApiResponses(value = {
@@ -163,8 +176,10 @@ public interface AdminPageControllerSpec {
     ResponseEntity<List<MemberInfoResponseDto>> readDrawMemberList(
             @Parameter(description = "Contest PK", example = "1")
             Long contestId,
+            @NotNull(message = "offset의 null값은 허용하지 않습니다.")
             @Parameter(description = "조회할 페이지 번호", example = "1")
             Integer offset,
+            @NotNull(message = "limit의 null값은 허용하지 않습니다.")
             @Parameter(description = "페이지당 조회할 데이터 개수", example = "1")
             Integer limit);
 

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
@@ -10,8 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminHomeResponseDto;
-import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.*;
 import sheetplus.checkings.domain.member.dto.MemberDto.MemberInfoResponseDto;
 import sheetplus.checkings.exception.error.ErrorResponse;
 
@@ -20,9 +19,9 @@ import java.util.List;
 @Tag(name = "Admin-Page", description = "Admin-Page Service API")
 public interface AdminPageControllerSpec {
 
-    @Operation(summary = "Admin-Page Home", description = "Admin-Page Home화면 데이터를 조회합니다")
+    @Operation(summary = "어드민 홈페이지 - 스탬프 통계", description = "Admin-Page Home화면의 스탬프 통계 데이터를 조회합니다")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Admin-Page Home화면 조회를 성공했습니다",
+            @ApiResponse(responseCode = "200", description = "Admin-Page Home화면의 스탬프 통계 데이터 조회를 성공했습니다",
                     content = @Content(array = @ArraySchema(schema =
                     @Schema(implementation = AdminHomeResponseDto.class)),
                             mediaType = "application/json"),
@@ -45,7 +44,94 @@ public interface AdminPageControllerSpec {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             mediaType = "application/json")),
     })
-    ResponseEntity<AdminHomeResponseDto> readAdminHome(
+    ResponseEntity<AdminStampStatsDto> readAdminHomeStampStats(
+            @Parameter(description = "Contest PK", example = "1")
+            Long contestId);
+
+    @Operation(summary = "어드민 홈페이지 - Contest 통계", description = "어드민 페이지 Home화면의 Contest 통계 데이터를 조회합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "어드민 페이지 Home화면의 Contest 통계 데이터 조회를 성공했습니다",
+                    content = @Content(array = @ArraySchema(schema =
+                    @Schema(implementation = AdminHomeResponseDto.class)),
+                            mediaType = "application/json"),
+                    headers = {@Header(name = "etag",
+                            description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
+                            @Header(name = "Cache-Control",
+                                    description = "클라이언트 캐시 사용, 캐싱 최대유효시간 1시간, 유효시간 지난 후에는 반드시 서버로 재요청하세요")}),
+            @ApiResponse(responseCode = "304", description = "캐시 데이터의 변경사항이 없습니다. 로컬 캐시 데이터를 사용하세요",
+                    content = @Content (mediaType = "None")),
+            @ApiResponse(responseCode = "400", description = "잘못된 HTTP 입력 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰이 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "[Contest] 정보를 찾을 수 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+    })
+    ResponseEntity<AdminContestStatsDto> readAdminHomeContestStats(
+            @Parameter(description = "Contest PK", example = "1")
+            Long contestId);
+
+    @Operation(summary = "어드민 홈페이지 - Event 통계", description = "어드민 페이지 Home화면의 Event 통계 데이터를 조회합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "어드민 페이지 Home화면의 Event 통계 데이터 조회를 성공했습니다",
+                    content = @Content(array = @ArraySchema(schema =
+                    @Schema(implementation = AdminHomeResponseDto.class)),
+                            mediaType = "application/json"),
+                    headers = {@Header(name = "etag",
+                            description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
+                            @Header(name = "Cache-Control",
+                                    description = "클라이언트 캐시 사용, 캐싱 최대유효시간 1시간, 유효시간 지난 후에는 반드시 서버로 재요청하세요")}),
+            @ApiResponse(responseCode = "304", description = "캐시 데이터의 변경사항이 없습니다. 로컬 캐시 데이터를 사용하세요",
+                    content = @Content (mediaType = "None")),
+            @ApiResponse(responseCode = "400", description = "잘못된 HTTP 입력 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰이 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "[Contest] 정보를 찾을 수 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+    })
+    ResponseEntity<AdminEventStatsDto> readAdminHomeEventStats(
+            @Parameter(description = "Contest PK", example = "1")
+            Long contestId);
+
+    @Operation(summary = "어드민 홈페이지 - Entry 통계", description = "어드민 홈페이지 - Entry 통계 데이터를 조회합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "어드민 홈페이지 - Entry 통계 데이터 조회를 성공했습니다",
+                    content = @Content(array = @ArraySchema(schema =
+                    @Schema(implementation = AdminHomeResponseDto.class)),
+                            mediaType = "application/json"),
+                    headers = {@Header(name = "etag",
+                            description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
+                            @Header(name = "Cache-Control",
+                                    description = "클라이언트 캐시 사용, 캐싱 최대유효시간 1시간, 유효시간 지난 후에는 반드시 서버로 재요청하세요")}),
+            @ApiResponse(responseCode = "304", description = "캐시 데이터의 변경사항이 없습니다. 로컬 캐시 데이터를 사용하세요",
+                    content = @Content (mediaType = "None")),
+            @ApiResponse(responseCode = "400", description = "잘못된 HTTP 입력 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰이 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "[Contest] 정보를 찾을 수 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+    })
+    ResponseEntity<AdminEntryStatsDto> readAdminHomeEntryStats(
             @Parameter(description = "Contest PK", example = "1")
             Long contestId);
 

--- a/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/controller/AdminPageControllerSpec.java
@@ -24,7 +24,7 @@ public interface AdminPageControllerSpec {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Admin-Page Home화면의 스탬프 통계 데이터 조회를 성공했습니다",
                     content = @Content(array = @ArraySchema(schema =
-                    @Schema(implementation = AdminHomeResponseDto.class)),
+                    @Schema(implementation = AdminStampStatsDto.class)),
                             mediaType = "application/json"),
                     headers = {@Header(name = "etag",
                             description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
@@ -53,7 +53,7 @@ public interface AdminPageControllerSpec {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "어드민 페이지 Home화면의 Contest 통계 데이터 조회를 성공했습니다",
                     content = @Content(array = @ArraySchema(schema =
-                    @Schema(implementation = AdminHomeResponseDto.class)),
+                    @Schema(implementation = AdminContestStatsDto.class)),
                             mediaType = "application/json"),
                     headers = {@Header(name = "etag",
                             description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
@@ -82,7 +82,7 @@ public interface AdminPageControllerSpec {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "어드민 페이지 Home화면의 Event 통계 데이터 조회를 성공했습니다",
                     content = @Content(array = @ArraySchema(schema =
-                    @Schema(implementation = AdminHomeResponseDto.class)),
+                    @Schema(implementation = AdminEventStatsDto.class)),
                             mediaType = "application/json"),
                     headers = {@Header(name = "etag",
                             description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
@@ -117,7 +117,7 @@ public interface AdminPageControllerSpec {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "어드민 홈페이지 - Entry 통계 데이터 조회를 성공했습니다",
                     content = @Content(array = @ArraySchema(schema =
-                    @Schema(implementation = AdminHomeResponseDto.class)),
+                    @Schema(implementation = AdminEntryStatsDto.class)),
                             mediaType = "application/json"),
                     headers = {@Header(name = "etag",
                             description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),

--- a/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
@@ -35,83 +35,6 @@ public class AdminPageDto {
     @Getter
     @Builder
     @NoArgsConstructor @AllArgsConstructor
-    @Schema(description = "Admin Home Response Dto", contentMediaType = "application/json")
-    public static class AdminHomeResponseDto{
-        // 좌상
-        @Schema(description = "Member 수",
-                example = "30", type = "String")
-        private String memberCounts;
-        @Schema(description = "모든 이벤트 유형에 참가한 Member 수",
-                example = "0", type = "String")
-        private String completeEventMemberCounts;
-        @Schema(description = "이벤트 참여 횟수가 1 이상인 Member 수",
-                example = "15", type = "String")
-        private String moreThanOneCounts;
-        @Schema(description = "이벤트 참여 횟수가 5 이상인 Member 수",
-                example = "4", type = "string")
-        private String moreThanFiveCounts;
-
-        // 우상 제목
-        @Schema(description = "Contest 이름",
-                example = "contest", type = "String")
-        private String contestName;
-        // 우상 1
-        @Schema(description = "Contest 시작시간",
-                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-        private LocalDateTime contestStart;
-        @Schema(description = "Contest 종료시간",
-                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-        private LocalDateTime contestEnd;
-        // 우상 2
-
-        @Schema(description = "이벤트 장소명",
-                example = "location", type = "String")
-        private String locationName;
-
-        @Schema(description = "이벤트 장소 수",
-                example = "100", type = "String")
-        private String locationCounts;
-        // 우상 3
-        @Schema(description = "남은 이벤트 수",
-                example = "30", type = "String")
-        private String remainEvents;
-        @Schema(description = "종료한 이벤트 수",
-                example = "50", type = "String")
-        private String finishEvents;
-        @Schema(description = "오늘 시작하지 않는 이벤트 수",
-                example = "20", type = "String")
-        private String notTodayEvents;
-        // 우상 3
-        @Schema(description = "출품작 학과 수",
-                example = "7", type = "String")
-        private String entryMajorCounts;
-        @Schema(description = "출품작 수",
-                example = "1500", type = "String")
-        private String entryCounts;
-        @Schema(description = "예선 출품작",
-                example = "1400", type = "String")
-        private String entryPreliminaryCounts;
-        @Schema(description = "본선 출품작",
-                example = "100", type = "String")
-        private String entryFinalCounts;
-        // 좌하
-
-        @Schema(description = "전체 이벤트 수",
-                example = "100", type = "String")
-        private String eventCounts;
-        @Schema(description = "모든 이벤트들", implementation = EventResponseDto.class)
-        private List<EventResponseDto> allEvents;
-
-        // 우하
-        @Schema(description = "모든 출품작들", implementation = EntryResponseDto.class)
-        private List<EntryResponseDto> entryPageable;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor @AllArgsConstructor
     @Schema(description = "Contest Info With Counts", contentMediaType = "application/json")
     public static class ContestInfoWithCounts{
         @Schema(description = "이벤트 명",
@@ -171,7 +94,7 @@ public class AdminPageDto {
 
         @Schema(description = "이벤트 장소 수",
                 example = "100", type = "String")
-        private Integer locationCounts;
+        private Long locationCounts;
         // 우상 3
         @Schema(description = "남은 이벤트 수",
                 example = "30", type = "String")
@@ -196,6 +119,72 @@ public class AdminPageDto {
                 example = "100", type = "String")
         private Long entryFinalCounts;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "어드민 페이지 대회정보 통계 - Contest정보", contentMediaType = "application/json")
+    public static class AdminContestStatsAboutContestDto{
+        // 우상 제목
+        @Schema(description = "Contest 이름",
+                example = "contest", type = "String")
+        private String contestName;
+
+        @Schema(description = "Contest 시작시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime contestStart;
+
+        @Schema(description = "Contest 종료시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime contestEnd;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "어드민 페이지 대회정보 통계 - Event통계", contentMediaType = "application/json")
+    public static class AdminContestStatsAboutEventDto{
+        @Schema(description = "이벤트 장소명",
+                example = "location", type = "String")
+        private String locationName;
+
+        @Schema(description = "이벤트 장소 수",
+                example = "100", type = "String")
+        private Long locationCounts;
+        // 우상 3
+        @Schema(description = "남은 이벤트 수",
+                example = "30", type = "String")
+        private Long remainEvents;
+        @Schema(description = "종료한 이벤트 수",
+                example = "50", type = "String")
+        private Long finishEvents;
+        @Schema(description = "오늘 시작하지 않는 이벤트 수",
+                example = "20", type = "String")
+        private Long notTodayEvents;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "어드민 페이지 대회정보 통계 - Entry통계", contentMediaType = "application/json")
+    public static class AdminContestStatsAboutEntryDto{
+        @Schema(description = "출품작 학과 수",
+                example = "7", type = "String")
+        private Long entryMajorCounts;
+        @Schema(description = "출품작 수",
+                example = "1500", type = "String")
+        private Long entryCounts;
+        @Schema(description = "예선 출품작",
+                example = "1400", type = "String")
+        private Long entryPreliminaryCounts;
+        @Schema(description = "본선 출품작",
+                example = "100", type = "String")
+        private Long entryFinalCounts;
+    }
+
+
 
     @Getter
     @Builder

--- a/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryResponseDto;
 import sheetplus.checkings.domain.enums.ContestCons;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
+import sheetplus.checkings.domain.participatecontest.dto.ParticipateContestDto.ParticipateInfoResponseDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -131,6 +132,89 @@ public class AdminPageDto {
         @Schema(description = "작품 개수",
                 example = "50", type = "Integer")
         private Integer entryCounts;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "어드민 페이지 스탬프 미션 완료 통계", contentMediaType = "application/json")
+    public static class AdminStampStatsDto{
+        private Long memberCounts;
+        private ParticipateInfoResponseDto participateInfoResponseDto;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "어드민 페이지 대회정보 통계", contentMediaType = "application/json")
+    public static class AdminContestStatsDto{
+        // 우상 제목
+        @Schema(description = "Contest 이름",
+                example = "contest", type = "String")
+        private String contestName;
+        // 우상 1
+        @Schema(description = "Contest 시작시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime contestStart;
+        @Schema(description = "Contest 종료시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime contestEnd;
+        // 우상 2
+
+        @Schema(description = "이벤트 장소명",
+                example = "location", type = "String")
+        private String locationName;
+
+        @Schema(description = "이벤트 장소 수",
+                example = "100", type = "String")
+        private Integer locationCounts;
+        // 우상 3
+        @Schema(description = "남은 이벤트 수",
+                example = "30", type = "String")
+        private Long remainEvents;
+        @Schema(description = "종료한 이벤트 수",
+                example = "50", type = "String")
+        private Long finishEvents;
+        @Schema(description = "오늘 시작하지 않는 이벤트 수",
+                example = "20", type = "String")
+        private Long notTodayEvents;
+        // 우상 3
+        @Schema(description = "출품작 학과 수",
+                example = "7", type = "String")
+        private Long entryMajorCounts;
+        @Schema(description = "출품작 수",
+                example = "1500", type = "String")
+        private Long entryCounts;
+        @Schema(description = "예선 출품작",
+                example = "1400", type = "String")
+        private Long entryPreliminaryCounts;
+        @Schema(description = "본선 출품작",
+                example = "100", type = "String")
+        private Long entryFinalCounts;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "어드민 페이지 이벤트 정보 통계", contentMediaType = "application/json")
+    public static class AdminEventStatsDto{
+        @Schema(description = "전체 이벤트 수",
+                example = "100", type = "String")
+        private Integer eventCounts;
+        @Schema(description = "모든 이벤트들", implementation = EventResponseDto.class)
+        private List<EventResponseDto> allEvents;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "어드민 페이지 작품 정보 통계", contentMediaType = "application/json")
+    public static class AdminEntryStatsDto{
+
+        @Schema(description = "모든 출품작들", implementation = EntryResponseDto.class)
+        private List<EntryResponseDto> entryPageable;
     }
 
 }

--- a/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
@@ -11,7 +11,6 @@ import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryResponseDto;
 import sheetplus.checkings.domain.enums.ContestCons;
 import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.participatecontest.dto.ParticipateContestDto.ParticipateInfoResponseDto;
 
 import java.time.LocalDateTime;

--- a/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/dto/AdminPageDto.java
@@ -7,8 +7,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryResponseDto;
 import sheetplus.checkings.domain.enums.ContestCons;
+import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.participatecontest.dto.ParticipateContestDto.ParticipateInfoResponseDto;
 
@@ -203,8 +205,8 @@ public class AdminPageDto {
         @Schema(description = "전체 이벤트 수",
                 example = "100", type = "String")
         private Integer eventCounts;
-        @Schema(description = "모든 이벤트들", implementation = EventResponseDto.class)
-        private List<EventResponseDto> allEvents;
+        @Schema(description = "모든 이벤트들", implementation = EventExceptLinksResponseDto.class)
+        private List<EventExceptLinksResponseDto> allEvents;
     }
 
     @Getter
@@ -214,7 +216,7 @@ public class AdminPageDto {
     public static class AdminEntryStatsDto{
 
         @Schema(description = "모든 출품작들", implementation = EntryResponseDto.class)
-        private List<EntryResponseDto> entryPageable;
+        private List<EntryExceptLinksResponseDto> entryPageable;
     }
 
 }

--- a/src/main/java/sheetplus/checkings/business/page/admin/service/AdminPageService.java
+++ b/src/main/java/sheetplus/checkings/business/page/admin/service/AdminPageService.java
@@ -8,10 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.*;
 import sheetplus.checkings.domain.contest.entity.Contest;
+import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto;
 import sheetplus.checkings.domain.event.entity.Event;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryInfoResponseDto;
-import sheetplus.checkings.domain.entry.dto.EntryDto.EntryResponseDto;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.member.dto.MemberDto.MemberInfoResponseDto;
 import sheetplus.checkings.domain.contest.repository.ContestRepository;
 import sheetplus.checkings.domain.entry.repository.EntryRepository;
@@ -108,54 +107,22 @@ public class AdminPageService {
     }
 
     @Transactional(readOnly = true)
-    public AdminEventStatsDto eventStatsDto(Long contestId){
+    public AdminEventStatsDto eventStatsDto(Long contestId, Pageable pageable){
         Contest contest = contestRepository
                 .findById(contestId).orElseThrow(() -> new ApiException(CONTEST_NOT_FOUND));
         List<Event> events = contest.getEvents();
 
-        return AdminEventStatsDto
-                .builder()
-                .eventCounts(events.size())
-                .allEvents(events.stream()
-                        .map(p -> EventResponseDto.builder()
-                                .id(p.getId())
-                                .name(p.getName())
-                                .startTime(p.getStartTime())
-                                .endTime(p.getEndTime())
-                                .location(p.getLocation())
-                                .building(p.getBuilding())
-                                .speakerName(p.getSpeakerName())
-                                .major(p.getMajor())
-                                .conditionMessage(p.getEventCondition().getMessage())
-                                .eventTypeMessage(p.getEventType().getMessage())
-                                .categoryMessage(p.getEventCategory().getMessage())
-                                .build())
-                        .toList())
-                .build();
+        return contestRepository.findContestWithEvents(contestId, pageable);
     }
 
     @Transactional(readOnly = true)
-    public AdminEntryStatsDto entryStatsDto(Long contestId){
-        Contest contest = contestRepository
-                .findById(contestId).orElseThrow(() -> new ApiException(CONTEST_NOT_FOUND));
-
-        List<EntryResponseDto> entryList = contest.getEntries().stream()
-                .map(p -> EntryResponseDto.builder()
-                        .id(p.getId())
-                        .entryType(p.getEntryType().getMessage())
-                        .professorName(p.getProfessorName())
-                        .major(p.getMajor())
-                        .teamNumber(p.getTeamNumber())
-                        .leaderName(p.getLeaderName())
-                        .location(p.getLocation())
-                        .building(p.getBuilding())
-                        .name(p.getName())
-                        .build())
-                .toList();
+    public AdminEntryStatsDto entryStatsDto(Long contestId, Pageable pageable){
+        List<EntryExceptLinksResponseDto> entryPageable =
+                contestRepository.findContestWithEntries(contestId, pageable);
 
         return AdminEntryStatsDto
                 .builder()
-                .entryPageable(entryList)
+                .entryPageable(entryPageable)
                 .build();
     }
 

--- a/src/main/java/sheetplus/checkings/business/page/common/controller/CommonPageController.java
+++ b/src/main/java/sheetplus/checkings/business/page/common/controller/CommonPageController.java
@@ -8,7 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sheetplus.checkings.domain.contest.dto.ContestDto.ContestInfoResponseDto;
 import sheetplus.checkings.business.page.common.service.CommonPageService;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
+import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
+
 
 import java.util.List;
 
@@ -32,7 +33,7 @@ public class CommonPageController implements CommonPageControllerSpec {
     }
 
     @GetMapping("public/contests/{contest}/schedules/v1")
-    public ResponseEntity<List<EventResponseDto>> readStudentSchedule(
+    public ResponseEntity<List<EventExceptLinksResponseDto>> readStudentSchedule(
             @PathVariable("contest")
             Long contestId,
             @RequestParam(value = "offset", required = false)

--- a/src/main/java/sheetplus/checkings/business/page/common/controller/CommonPageControllerSpec.java
+++ b/src/main/java/sheetplus/checkings/business/page/common/controller/CommonPageControllerSpec.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import sheetplus.checkings.domain.contest.dto.ContestDto.ContestInfoResponseDto;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
+import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
 import sheetplus.checkings.exception.error.ErrorResponse;
 
 import java.util.List;
@@ -48,7 +48,7 @@ public interface CommonPageControllerSpec {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "일정 페이지 데이터 조회 성공",
                     content = @Content(array = @ArraySchema(schema =
-                    @Schema(implementation = EventResponseDto.class)),
+                    @Schema(implementation = EventExceptLinksResponseDto.class)),
                             mediaType = "application/json"),
                     headers = {@Header(name = "etag",
                             description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
@@ -60,7 +60,7 @@ public interface CommonPageControllerSpec {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             mediaType = "application/json"))
     })
-    ResponseEntity<List<EventResponseDto>> readStudentSchedule(
+    ResponseEntity<List<EventExceptLinksResponseDto>> readStudentSchedule(
             @Parameter(description = "Contest PK", example = "1")
             Long contestId,
             @Parameter(description = "조회할 페이지 번호", example = "1")

--- a/src/main/java/sheetplus/checkings/business/page/common/service/CommonPageService.java
+++ b/src/main/java/sheetplus/checkings/business/page/common/service/CommonPageService.java
@@ -9,9 +9,12 @@ import org.springframework.transaction.annotation.Transactional;
 import sheetplus.checkings.domain.contest.dto.ContestDto.ContestInfoResponseDto;
 import sheetplus.checkings.domain.contest.entity.Contest;
 import sheetplus.checkings.domain.contest.repository.ContestRepository;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
+import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
+import sheetplus.checkings.exception.exceptionMethod.ApiException;
 
 import java.util.List;
+
+import static sheetplus.checkings.exception.error.ApiError.CONTEST_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -22,19 +25,15 @@ public class CommonPageService {
 
     @Transactional(readOnly = true)
     public List<ContestInfoResponseDto> readContestInfo(Pageable pageable){
-        List<Contest> contests = contestRepository.findAll(pageable).getContent();
-
-        return contests.stream()
-                .map(a -> ContestInfoResponseDto.builder()
-                        .contestId(a.getId())
-                        .contestName(a.getName())
-                        .build())
-                .toList();
+        return contestRepository.findAllContestInfo(pageable);
     }
 
     @Transactional(readOnly = true)
-    public List<EventResponseDto> readStudentSchedulePage(Long contestId, Pageable pageable){
-        return contestRepository.findTodayEvents(contestId, pageable);
+    public List<EventExceptLinksResponseDto> readStudentSchedulePage(Long contestId, Pageable pageable){
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(() -> new ApiException(CONTEST_NOT_FOUND));
+
+        return contestRepository.findTodayEvents(contest.getId(), pageable);
     }
 
 }

--- a/src/main/java/sheetplus/checkings/business/page/student/controller/StudentPageController.java
+++ b/src/main/java/sheetplus/checkings/business/page/student/controller/StudentPageController.java
@@ -5,7 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sheetplus.checkings.business.page.student.dto.StudentPageDto.ActivitiesResponseDto;
-import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomePageResponseDto;
+import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomeEventsInfoResponseDto;
+import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomeMemberAndStampInfoResponseDto;
 import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentPageActivitiesResponseDto;
 import sheetplus.checkings.business.page.student.service.StudentPageService;
 
@@ -17,16 +18,25 @@ public class StudentPageController implements StudentPageControllerSpec{
 
     private final StudentPageService studentPageService;
 
-    @GetMapping("/contests/{contest}/home/v1")
-    public ResponseEntity<StudentHomePageResponseDto> readStudentHome(
+    @GetMapping("/contests/{contest}/homes/stamp-info/v2")
+    public ResponseEntity<StudentHomeMemberAndStampInfoResponseDto> readStudentHomeMemberWithStampInfo(
             @RequestHeader(value = "Authorization", required = false) String token,
             @PathVariable("contest") Long contestId){
 
         token = token.replace("Bearer ", "");
 
-        return ResponseEntity.ok(studentPageService.readStudentHomePage(token, contestId));
+        return ResponseEntity.ok(studentPageService.readStudentHomeMemberAndStampInfo(token, contestId));
     }
 
+    @GetMapping("/contests/{contest}/homes/event-info/v2")
+    public ResponseEntity<StudentHomeEventsInfoResponseDto> readStudentHomeEventInfo(
+            @PathVariable("contest") Long contestId,
+            @RequestParam(value = "building") String building
+            ){
+
+        return ResponseEntity.ok(studentPageService
+                .readStudentHomeEventInfo(contestId, building));
+    }
 
 
     @GetMapping("/contests/{contest}/activities/v1")

--- a/src/main/java/sheetplus/checkings/business/page/student/controller/StudentPageControllerSpec.java
+++ b/src/main/java/sheetplus/checkings/business/page/student/controller/StudentPageControllerSpec.java
@@ -9,7 +9,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomePageResponseDto;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomeEventsInfoResponseDto;
+import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomeMemberAndStampInfoResponseDto;
 import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentPageActivitiesResponseDto;
 import sheetplus.checkings.exception.error.ErrorResponse;
 
@@ -17,11 +20,11 @@ import sheetplus.checkings.exception.error.ErrorResponse;
 public interface StudentPageControllerSpec {
 
 
-    @Operation(summary = "Student-Page Home GET", description = "학생 페이지 Home 화면 데이터를 조회합니다.")
+    @Operation(summary = "학생 Home 페이지 학생 정보 및 참여한 스탬프 개수 GET", description = "학생 Home 페이지 학생 정보 및 참여한 스탬프 개수를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "학생 페이지 Home 화면 데이터 조회 성공",
+            @ApiResponse(responseCode = "200", description = "학생 Home 페이지 학생 정보 및 참여한 스탬프 개수 데이터 조회 성공",
                     content = @Content(schema =
-                    @Schema(implementation = StudentHomePageResponseDto.class),
+                    @Schema(implementation = StudentHomeMemberAndStampInfoResponseDto.class),
                             mediaType = "application/json"),
                     headers = {@Header(name = "etag",
                             description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
@@ -39,12 +42,41 @@ public interface StudentPageControllerSpec {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             mediaType = "application/json")),
     })
-    ResponseEntity<StudentHomePageResponseDto> readStudentHome(
+    ResponseEntity<StudentHomeMemberAndStampInfoResponseDto> readStudentHomeMemberWithStampInfo(
             @Parameter(description = "액세스 토큰입니다 Header에 포함해서 요청하세요", hidden = true)
             String token,
             @Parameter(description = "Contest PK", example = "1")
             Long contestId
     );
+
+    @Operation(summary = "학생 Home페이지 오늘 참여할 수 있는 이벤트 GET", description = "학생 Home페이지 오늘 참여할 수 있는 이벤트 데이터를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "학생 Home페이지 오늘 참여할 수 있는 이벤트 데이터 조회 성공",
+                    content = @Content(schema =
+                    @Schema(implementation = StudentHomeEventsInfoResponseDto.class),
+                            mediaType = "application/json"),
+                    headers = {@Header(name = "etag",
+                            description = "\"etagexample\"과 같은 형태로 제공됩니다. If-None-Match속성에 Etag를 추가해서 요청하세요"),
+                            @Header(name = "Cache-Control",
+                                    description = "클라이언트 캐시 사용, 캐싱 최대유효시간 1시간, 유효시간 지난 후에는 반드시 서버로 재요청하세요")}),
+            @ApiResponse(responseCode = "304", description = "캐시 데이터의 변경사항이 없습니다. 로컬 캐시 데이터를 사용하세요",
+                    content = @Content (mediaType = "None")),
+            @ApiResponse(responseCode = "400", description = "잘못된 HTTP 입력 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰이 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "[Member]정보를 찾을 수 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            mediaType = "application/json")),
+    })
+    ResponseEntity<StudentHomeEventsInfoResponseDto> readStudentHomeEventInfo(
+            @Parameter(description = "Contest PK", example = "1")
+            @PathVariable("contest") Long contestId,
+            @Parameter(description = "탐색할 이벤트 건물", example = "인문과학관")
+            @RequestParam(value = "building") String building);
+
 
     @Operation(summary = "Student-Page activities GET", description = "학생 페이지 Activity 화면 데이터를 조회합니다.")
     @ApiResponses(value = {

--- a/src/main/java/sheetplus/checkings/business/page/student/dto/StudentPageDto.java
+++ b/src/main/java/sheetplus/checkings/business/page/student/dto/StudentPageDto.java
@@ -28,19 +28,26 @@ public class StudentPageDto {
     @Getter
     @Builder
     @NoArgsConstructor @AllArgsConstructor
-    @Schema(description = "Student Home Page Response Dto", contentMediaType = "application/json")
-    public static class StudentHomePageResponseDto{
+    @Schema(description = "Member 및 Stamp정보 응답 Dto", contentMediaType = "application/json")
+    public static class StudentHomeMemberAndStampInfoResponseDto{
         @Schema(description = "학생 이름",
                 example = "studentMember", type = "String")
         private String studentName;
         @Schema(description = "학생 전공",
                 example = "studentMajor", type = "String")
         private String studentMajor;
-        @Schema(description = "전체 이벤트 수",
-                example = "100", type = "String")
-        private String eventCounts;
+        @Schema(description = "이벤트 참여 수",
+                example = "2", type = "String")
+        private Integer participateEventCounts;
+    }
 
-        @Schema(description = "모든 이벤트들", implementation = EventExceptLinksResponseDto.class)
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "Student Home Page Response Dto", contentMediaType = "application/json")
+    public static class StudentHomeEventsInfoResponseDto{
+
+        @Schema(description = "오늘 참여할 수 있는 이벤트들", implementation = EventExceptLinksResponseDto.class)
         private List<EventExceptLinksResponseDto> events;
     }
 

--- a/src/main/java/sheetplus/checkings/business/page/student/dto/StudentPageDto.java
+++ b/src/main/java/sheetplus/checkings/business/page/student/dto/StudentPageDto.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
+import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
 import sheetplus.checkings.domain.favorite.dto.FavoriteDto.FavoriteResponseDto;
 
 import java.util.List;
@@ -40,8 +40,8 @@ public class StudentPageDto {
                 example = "100", type = "String")
         private String eventCounts;
 
-        @Schema(description = "모든 이벤트들", implementation = EventResponseDto.class)
-        private List<EventResponseDto> events;
+        @Schema(description = "모든 이벤트들", implementation = EventExceptLinksResponseDto.class)
+        private List<EventExceptLinksResponseDto> events;
     }
 
     @Getter
@@ -49,11 +49,11 @@ public class StudentPageDto {
     @NoArgsConstructor @AllArgsConstructor
     @Schema(description = "Activities Response Dto", contentMediaType = "application/json")
     public static class ActivitiesResponseDto{
-        @Schema(description = "전체 이벤트 수",
-                example = "100", type = "String")
-        private String eventCounts;
-        @Schema(description = "모든 이벤트들", implementation = EventResponseDto.class)
-        private List<EventResponseDto> events;
+        @Schema(description = "참여한 이벤트 수",
+                example = "3", type = "String")
+        private Integer eventCounts;
+        @Schema(description = "참여한 대회들", implementation = EventExceptLinksResponseDto.class)
+        private List<EventExceptLinksResponseDto> events;
     }
 
 

--- a/src/main/java/sheetplus/checkings/business/page/student/service/StudentPageService.java
+++ b/src/main/java/sheetplus/checkings/business/page/student/service/StudentPageService.java
@@ -6,18 +6,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sheetplus.checkings.business.page.student.dto.StudentPageDto.ActivitiesResponseDto;
-import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomePageResponseDto;
+import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomeEventsInfoResponseDto;
+import sheetplus.checkings.business.page.student.dto.StudentPageDto.StudentHomeMemberAndStampInfoResponseDto;
 import sheetplus.checkings.domain.member.entity.Member;
 import sheetplus.checkings.domain.participatecontest.entity.ParticipateContest;
-import sheetplus.checkings.domain.enums.EventCategory;
 import sheetplus.checkings.domain.contest.repository.ContestRepository;
 import sheetplus.checkings.domain.member.repository.MemberRepository;
 import sheetplus.checkings.domain.participatecontest.repository.ParticipateContestStateRepository;
 import sheetplus.checkings.exception.exceptionMethod.ApiException;
 import sheetplus.checkings.util.JwtUtil;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static sheetplus.checkings.exception.error.ApiError.MEMBER_NOT_FOUND;
 import static sheetplus.checkings.exception.error.ApiError.PARTICIPATE_NOT_FOUND;
@@ -34,19 +31,25 @@ public class StudentPageService {
 
 
     @Transactional(readOnly = true)
-    public StudentHomePageResponseDto readStudentHomePage(String token, Long contestId) {
+    public StudentHomeMemberAndStampInfoResponseDto readStudentHomeMemberAndStampInfo(String token, Long contestId) {
         Member member = memberRepository.findByIdAndWithGraph(jwtUtil.getMemberId(token))
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         Integer count = participateContestStateRepository
                 .participateCounts(member.getId(), contestId);
 
 
-        return StudentHomePageResponseDto.builder()
+        return StudentHomeMemberAndStampInfoResponseDto.builder()
                 .studentName(member.getName())
                 .studentMajor(member.getMajor())
-                .eventCounts(Integer.toString(count))
+                .participateEventCounts(count == null ? 0 : count)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public StudentHomeEventsInfoResponseDto readStudentHomeEventInfo(Long contestId, String building) {
+        return StudentHomeEventsInfoResponseDto.builder()
                 .events(contestRepository.findNowAfterEvents(
-                        contestId))
+                        contestId, building))
                 .build();
     }
 

--- a/src/main/java/sheetplus/checkings/business/page/student/service/StudentPageService.java
+++ b/src/main/java/sheetplus/checkings/business/page/student/service/StudentPageService.java
@@ -37,7 +37,8 @@ public class StudentPageService {
     public StudentHomePageResponseDto readStudentHomePage(String token, Long contestId) {
         Member member = memberRepository.findByIdAndWithGraph(jwtUtil.getMemberId(token))
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
-        Integer count = participateContestStateRepository.participateCounts(member.getId(), contestId);
+        Integer count = participateContestStateRepository
+                .participateCounts(member.getId(), contestId);
 
 
         return StudentHomePageResponseDto.builder()
@@ -60,13 +61,10 @@ public class StudentPageService {
                         jwtUtil.getMemberId(token),contestId)
                 .orElseThrow(() -> new ApiException(PARTICIPATE_NOT_FOUND));
 
-        List<EventCategory> events = new ArrayList<>(participateContest.getEventTypeSet());
-
-
         return ActivitiesResponseDto
                 .builder()
-                .eventCounts(participateContest.getEventsCount().toString())
-                .events(contestRepository.findParticipateEvents(contestId, events))
+                .eventCounts(participateContest.getEventsCount())
+                .events(contestRepository.findParticipateEvents(participateContest.getId()))
                 .build();
     }
 

--- a/src/main/java/sheetplus/checkings/business/qrcode/controller/QrController.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/controller/QrController.java
@@ -9,6 +9,7 @@ import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeCreateResponseDto
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeRequestDto;
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeResponseDto;
 import sheetplus.checkings.business.qrcode.service.QrcodeService;
+import sheetplus.checkings.util.JwtUtil;
 
 
 @RestController
@@ -18,6 +19,7 @@ import sheetplus.checkings.business.qrcode.service.QrcodeService;
 public class QrController implements QrControllerSpec{
 
     private final QrcodeService qrcodeService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/student/qrcode/v1")
     public ResponseEntity<QrcodeResponseDto> qrcodeCheck(
@@ -27,7 +29,7 @@ public class QrController implements QrControllerSpec{
 
         QrcodeResponseDto qrcodeResponseDto
                 = qrcodeService.createParticipation(
-                        token.replace("Bearer","").trim(), qrcodeRequestDto);
+                jwtUtil.getMemberId(token.replace("Bearer","").trim()), qrcodeRequestDto);
 
         return ResponseEntity.ok(qrcodeResponseDto);
     }

--- a/src/main/java/sheetplus/checkings/business/qrcode/controller/QrController.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/controller/QrController.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeCreateRequestDto;
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeCreateResponseDto;
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeRequestDto;
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeResponseDto;
@@ -34,15 +35,15 @@ public class QrController implements QrControllerSpec{
         return ResponseEntity.ok(qrcodeResponseDto);
     }
 
-    @GetMapping("/admin/events/{eventId}/qrcode/v1")
+    @PostMapping("/admin/events/qrcode/v1")
     public ResponseEntity<QrcodeCreateResponseDto> createQrcode(
             @RequestHeader(value = "Authorization", required = false)
             String token,
-            @PathVariable(name = "eventId") Long id){
+            @RequestBody @Validated QrcodeCreateRequestDto qrcodeCreateRequestDto){
 
         QrcodeCreateResponseDto qrcodeCreateResponseDto
                 = qrcodeService.createQrcode(
-                        token.replace("Bearer","").trim(), id);
+                        token.replace("Bearer","").trim(), qrcodeCreateRequestDto.getEventId());
 
         return ResponseEntity.ok()
                 .header("Cache-Control", "no-store")

--- a/src/main/java/sheetplus/checkings/business/qrcode/controller/QrControllerSpec.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/controller/QrControllerSpec.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeCreateRequestDto;
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeCreateResponseDto;
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeRequestDto;
 import sheetplus.checkings.business.qrcode.dto.QrCodeDto.QrcodeResponseDto;
@@ -68,6 +69,6 @@ public interface QrControllerSpec{
             @Parameter(description = "액세스 토큰입니다 Header에 포함해서 요청하세요", hidden = true)
             String token,
             @Parameter(description = "Event PK", example = "1")
-            Long id);
+            QrcodeCreateRequestDto qrcodeCreateRequestDto);
 
 }

--- a/src/main/java/sheetplus/checkings/business/qrcode/dto/QrCodeDto.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/dto/QrCodeDto.java
@@ -23,9 +23,9 @@ public class QrCodeDto {
         @Schema(description = "암호화된 Event PK",
                 example = "987secure6543Id", type = "String")
         private String secureId;
-        @Schema(description = "만료시간을 암호화하는 Key",
-                example = "987secure6543Key", type = "String")
-        private String secretKey;
+        @Schema(description = "암호화된 만료시간",
+                example = "987secure6543expireTime", type = "String")
+        private String secretExpireTime;
     }
 
     @Getter

--- a/src/main/java/sheetplus/checkings/business/qrcode/dto/QrCodeDto.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/dto/QrCodeDto.java
@@ -18,6 +18,17 @@ public class QrCodeDto {
     @Getter
     @Builder
     @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "QRcode Create Request Dto", contentMediaType = "application/json")
+    public static class QrcodeCreateRequestDto{
+        @NotNull(message = "null은 허용하지 않습니다.")
+        @Schema(description = "Event PK",
+                example = "1", type = "String")
+        private Long eventId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
     @Schema(description = "QRcode Create Response Dto", contentMediaType = "application/json")
     public static class QrcodeCreateResponseDto{
         @Schema(description = "암호화된 Event PK",
@@ -66,6 +77,8 @@ public class QrCodeDto {
         @Schema(description = "HATEOAS 링크 - ref와 href만 제공")
         private List<Link> link;
     }
+
+
 
 
 }

--- a/src/main/java/sheetplus/checkings/business/qrcode/service/QrcodeService.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/service/QrcodeService.java
@@ -147,6 +147,7 @@ public class QrcodeService {
                 .build();
         participateContest.setContestParticipateContestStates(contest);
         participateContest.setMemberParticipateContestStates(member);
+        event.setEventParticipateContest(participateContest);
         participateContest.getEventTypeSet().add(event.getEventCategory());
         participateContestStateRepository.save(participateContest);
 

--- a/src/main/java/sheetplus/checkings/business/qrcode/service/QrcodeService.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/service/QrcodeService.java
@@ -114,7 +114,10 @@ public class QrcodeService {
         }
         List<Link> links = new ArrayList<>();
         links.add(linkTo(methodOn(StudentPageController.class)
-                .readStudentHome("인증 토큰", contest.getId()))
+                .readStudentHomeMemberWithStampInfo("인증 토큰", contest.getId()))
+                .withRel("학생 Home 페이지"));
+        links.add(linkTo(methodOn(StudentPageController.class)
+                .readStudentHomeEventInfo(contest.getId(), "인문과학관"))
                 .withRel("학생 Home 페이지"));
         links.add(linkTo(methodOn(StudentPageController.class)
                 .readStudentActivities("인증 토큰", contest.getId()))

--- a/src/main/java/sheetplus/checkings/business/qrcode/service/QrcodeService.java
+++ b/src/main/java/sheetplus/checkings/business/qrcode/service/QrcodeService.java
@@ -55,25 +55,30 @@ public class QrcodeService {
      * 9. participateContest이 null이 아닌 경우, Event의 타입 포함여부 확인 - 포함된 경우 EVENT_ALREADY_PARTICIPATE 예외 발생
      * 10. 8번 이후, 참여대회 수, 참여 대회 타입 저장 - 변경감지로 DB UPDATE 반영
      *
-     * @param token - 사용자 정보
+     * @param memberId - 멤버 PK
      * @param qrcodeRequestDto - 암호화된 Event 엔티티 PK
      * @return QrcodeResponseDto - 학생명/학번/이름명 Return
      */
     @Transactional
-    public QrcodeResponseDto createParticipation(String token, QrcodeRequestDto qrcodeRequestDto){
+    public QrcodeResponseDto createParticipation(Long memberId, QrcodeRequestDto qrcodeRequestDto){
         // 1번 로직
         Long id = cryptoUtil.decrypt(qrcodeRequestDto.getSecureCode());
 
         // 2번 로직
         LocalDateTime expireTime = cryptoUtil
                 .decryptExpireTime(qrcodeRequestDto.getSecureExpireTime());
+        if(expireTime == null){
+            throw new ApiException(QR_EXPIRED_TIME_NOT_VALID);
+        }
+
         if(LocalDateTime.now().isBefore(expireTime.plusSeconds(3))
-        && LocalDateTime.now().isAfter(expireTime.minusMinutes(16))){
+        && LocalDateTime.now().isAfter(expireTime.minusSeconds(16))){
+            log.info("만료시간: {}", expireTime);
             throw new ApiException(EXPIRED_QR_CODES);
         }
 
         // 3번 로직
-        Member member = memberRepository.findById(jwtUtil.getMemberId(token))
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         Event event = eventRepository.findById(id)
                 .orElseThrow(() -> new ApiException(EVENT_NOT_FOUND));
@@ -109,10 +114,10 @@ public class QrcodeService {
         }
         List<Link> links = new ArrayList<>();
         links.add(linkTo(methodOn(StudentPageController.class)
-                .readStudentHome(token, contest.getId()))
+                .readStudentHome("인증 토큰", contest.getId()))
                 .withRel("학생 Home 페이지"));
         links.add(linkTo(methodOn(StudentPageController.class)
-                .readStudentActivities(token, contest.getId()))
+                .readStudentActivities("인증 토큰", contest.getId()))
                 .withRel("학생 활동 페이지"));
 
         return QrcodeResponseDto.builder()
@@ -179,13 +184,13 @@ public class QrcodeService {
 
         // 3번 로직
         String secureId = cryptoUtil.encrypt(id);
-        String secretKey = cryptoUtil.getSECRET_KEY();
+        String secretExpireTime = cryptoUtil.encryptExpireTime(LocalDateTime.now());
 
 
         // 4번 로직
         return QrcodeCreateResponseDto.builder()
                 .secureId(secureId)
-                .secretKey(secretKey)
+                .secretExpireTime(secretExpireTime)
                 .build();
     }
 

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
@@ -4,19 +4,20 @@ import org.springframework.data.domain.Pageable;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminContestStatsDto;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminEventStatsDto;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
+import sheetplus.checkings.domain.contest.dto.ContestDto.ContestInfoResponseDto;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
-import sheetplus.checkings.domain.enums.EventCategory;
+import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
 
 import java.util.List;
 
 public interface ContestRepositoryCustom {
 
-    List<EventResponseDto> findNowAfterEvents(Long contestId);
-    List<EventResponseDto> findTodayEvents(Long contestId, Pageable pageable);
-    List<EventResponseDto> findParticipateEvents(Long contestId, List<EventCategory> category);
+    List<EventExceptLinksResponseDto> findNowAfterEvents(Long contestId);
+    List<EventExceptLinksResponseDto> findTodayEvents(Long contestId, Pageable pageable);
+    List<EventExceptLinksResponseDto> findParticipateEvents(Long ParticipateId);
     List<ContestInfoWithCounts> findContestInfoWithCounts();
     List<EntryExceptLinksResponseDto> findContestWithEntries(Long contestId, Pageable pageable);
     AdminEventStatsDto findContestWithEvents(Long contestId, Pageable pageable);
     AdminContestStatsDto findContestStats(Long contestId);
+    List<ContestInfoResponseDto> findAllContestInfo(Pageable pageable);
 }

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
@@ -1,6 +1,7 @@
 package sheetplus.checkings.domain.contest.repository;
 
 import org.springframework.data.domain.Pageable;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminContestStatsDto;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminEventStatsDto;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto;
@@ -17,4 +18,5 @@ public interface ContestRepositoryCustom {
     List<ContestInfoWithCounts> findContestInfoWithCounts();
     List<EntryExceptLinksResponseDto> findContestWithEntries(Long contestId, Pageable pageable);
     AdminEventStatsDto findContestWithEvents(Long contestId, Pageable pageable);
+    AdminContestStatsDto findContestStats(Long contestId);
 }

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
@@ -1,7 +1,9 @@
 package sheetplus.checkings.domain.contest.repository;
 
 import org.springframework.data.domain.Pageable;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminEventStatsDto;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
+import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.enums.EventCategory;
 
@@ -13,5 +15,6 @@ public interface ContestRepositoryCustom {
     List<EventResponseDto> findTodayEvents(Long contestId, Pageable pageable);
     List<EventResponseDto> findParticipateEvents(Long contestId, List<EventCategory> category);
     List<ContestInfoWithCounts> findContestInfoWithCounts();
-
+    List<EntryExceptLinksResponseDto> findContestWithEntries(Long contestId, Pageable pageable);
+    AdminEventStatsDto findContestWithEvents(Long contestId, Pageable pageable);
 }

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustom.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface ContestRepositoryCustom {
 
-    List<EventExceptLinksResponseDto> findNowAfterEvents(Long contestId);
+    List<EventExceptLinksResponseDto> findNowAfterEvents(Long contestId, String building);
     List<EventExceptLinksResponseDto> findTodayEvents(Long contestId, Pageable pageable);
     List<EventExceptLinksResponseDto> findParticipateEvents(Long ParticipateId);
     List<ContestInfoWithCounts> findContestInfoWithCounts();

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
@@ -88,7 +88,7 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
     }
 
     @Override
-    public List<EventExceptLinksResponseDto> findNowAfterEvents(Long contestId) {
+    public List<EventExceptLinksResponseDto> findNowAfterEvents(Long contestId, String building) {
         return queryFactory.select(
                         Projections.constructor(
                                 EventExceptLinksResponseDto.class,
@@ -130,13 +130,14 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
                                         .otherwise("unknown Category")
                                         .as("categoryMessage")
                         )
-                )
+                ).distinct()
                 .from(event)
                 .innerJoin(contest)
                 .on(event.eventContest.id.eq(contestId))
                 .where(event.eventContest.id.eq(contestId)
                         .and(event.startTime.after(LocalDateTime.now())
                                 .or(event.endTime.after(LocalDateTime.now())))
+                        .and(event.building.eq(building))
                 )
                 .fetch();
     }
@@ -185,6 +186,7 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
                                                 .as("categoryMessage")
                                 )
                         )
+                .distinct()
                 .from(event)
                 .innerJoin(participateContest)
                 .on(event.eventParticipateContest.id.eq(participateId))
@@ -227,6 +229,7 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
                                 .otherwise("Unknown Type")
                                 .as("entryType")
                 ))
+                .distinct()
                 .from(contest)
                 .innerJoin(entry)
                 .on(entry.entryContest.id.eq(contestId))

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
@@ -7,26 +7,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.*;
+import sheetplus.checkings.domain.contest.dto.ContestDto.ContestInfoResponseDto;
 import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto;
 import sheetplus.checkings.domain.enums.ContestCons;
 import sheetplus.checkings.domain.enums.EntryType;
 import sheetplus.checkings.domain.enums.EventType;
 import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
-import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
-import sheetplus.checkings.domain.contest.entity.Contest;
-import sheetplus.checkings.domain.event.entity.Event;
 import sheetplus.checkings.domain.enums.EventCategory;
-import sheetplus.checkings.exception.exceptionMethod.ApiException;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import static sheetplus.checkings.domain.contest.entity.QContest.contest;
 import static sheetplus.checkings.domain.entry.entity.QEntry.entry;
 import static sheetplus.checkings.domain.event.entity.QEvent.event;
 import static sheetplus.checkings.domain.participatecontest.entity.QParticipateContest.participateContest;
-import static sheetplus.checkings.exception.error.ApiError.CONTEST_NOT_FOUND;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -35,87 +30,165 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<EventResponseDto> findTodayEvents(Long contestId, Pageable pageable) {
-        Contest findContest = queryFactory.selectFrom(contest)
-                .join(contest.participateContestStateContest, participateContest)
-                .fetchJoin()
-                .where(contest.id.eq(contestId))
-                .fetchFirst();
-
-        if(findContest == null){
-            throw new ApiException(CONTEST_NOT_FOUND);
-        }
-
-        List<Event> events = queryFactory.selectFrom(event)
-                .where(event.eventContest.id.eq(findContest.getId())
-                        .and(event.startTime.dayOfMonth().eq(LocalDateTime.now().getDayOfMonth())
-                                .or(event.endTime.dayOfMonth().eq(LocalDateTime.now().getDayOfMonth())))
+    public List<EventExceptLinksResponseDto> findTodayEvents(Long contestId, Pageable pageable) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                EventExceptLinksResponseDto.class,
+                                event.id,
+                                event.name,
+                                event.startTime,
+                                event.endTime,
+                                event.location,
+                                event.building,
+                                event.speakerName,
+                                event.major,
+                                event.eventCondition
+                                        .when(ContestCons.EVENT_PROGRESS)
+                                        .then(ContestCons.EVENT_PROGRESS.getMessage())
+                                        .when(ContestCons.EVENT_BEFORE)
+                                        .then(ContestCons.EVENT_BEFORE.getMessage())
+                                        .when(ContestCons.EVENT_FINISH)
+                                        .then(ContestCons.EVENT_FINISH.getMessage())
+                                        .otherwise("Unknown Condition")
+                                        .as("conditionMessage"),
+                                event.eventType
+                                        .when(EventType.NO_CHECKING)
+                                        .then(EventType.NO_CHECKING.getMessage())
+                                        .when(EventType.CHECKING)
+                                        .then(EventType.CHECKING.getMessage())
+                                        .otherwise("Unknown Type")
+                                        .as("eventTypeMessage"),
+                                event.eventCategory
+                                        .when(EventCategory.EVENT_ONE)
+                                        .then(EventCategory.EVENT_ONE.getMessage())
+                                        .when(EventCategory.EVENT_TWO)
+                                        .then(EventCategory.EVENT_TWO.getMessage())
+                                        .when(EventCategory.EVENT_THREE)
+                                        .then(EventCategory.EVENT_THREE.getMessage())
+                                        .when(EventCategory.EVENT_FOUR)
+                                        .then(EventCategory.EVENT_FOUR.getMessage())
+                                        .when(EventCategory.EVENT_FIVE)
+                                        .then(EventCategory.EVENT_FIVE.getMessage())
+                                        .otherwise("unknown Category")
+                                        .as("categoryMessage")
+                        )
+                ).distinct()
+                .from(contest)
+                .innerJoin(event)
+                .on(event.eventContest.id.eq(contestId))
+                .where(event.startTime.dayOfMonth().loe(LocalDateTime.now().getDayOfMonth())
+                        .and(event.endTime.dayOfMonth().goe(LocalDateTime.now().getDayOfMonth()))
+                        .and(event.startTime.before(LocalDateTime.now()))
+                        .and(event.endTime.after(LocalDateTime.now()))
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-
-        return getEventResponseDtos(events);
-    }
-
-    private List<EventResponseDto> getEventResponseDtos(List<Event> events) {
-        return events.stream()
-                .map(p -> EventResponseDto.builder()
-                        .id(p.getId())
-                        .name(p.getName())
-                        .major(p.getMajor())
-                        .eventTypeMessage(p.getEventType().getMessage())
-                        .conditionMessage(p.getEventCondition().getMessage())
-                        .location(p.getLocation())
-                        .building(p.getBuilding())
-                        .categoryMessage(p.getEventCategory().getMessage())
-                        .speakerName(p.getSpeakerName())
-                        .startTime(p.getStartTime())
-                        .endTime(p.getEndTime())
-                        .build())
-                .toList();
     }
 
     @Override
-    public List<EventResponseDto> findNowAfterEvents(Long contestId) {
-        Contest findContest = queryFactory.selectFrom(contest)
-                .where(contest.id.eq(contestId))
-                .fetchFirst();
-
-        if(findContest == null){
-            throw new ApiException(CONTEST_NOT_FOUND);
-        }
-
-        List<Event> events = queryFactory.selectFrom(event)
-                .where(event.eventContest.id.eq(findContest.getId())
+    public List<EventExceptLinksResponseDto> findNowAfterEvents(Long contestId) {
+        return queryFactory.select(
+                        Projections.constructor(
+                                EventExceptLinksResponseDto.class,
+                                event.id,
+                                event.name,
+                                event.startTime,
+                                event.endTime,
+                                event.location,
+                                event.building,
+                                event.speakerName,
+                                event.major,
+                                event.eventCondition
+                                        .when(ContestCons.EVENT_PROGRESS)
+                                        .then(ContestCons.EVENT_PROGRESS.getMessage())
+                                        .when(ContestCons.EVENT_BEFORE)
+                                        .then(ContestCons.EVENT_BEFORE.getMessage())
+                                        .when(ContestCons.EVENT_FINISH)
+                                        .then(ContestCons.EVENT_FINISH.getMessage())
+                                        .otherwise("Unknown Condition")
+                                        .as("conditionMessage"),
+                                event.eventType
+                                        .when(EventType.NO_CHECKING)
+                                        .then(EventType.NO_CHECKING.getMessage())
+                                        .when(EventType.CHECKING)
+                                        .then(EventType.CHECKING.getMessage())
+                                        .otherwise("Unknown Type")
+                                        .as("eventTypeMessage"),
+                                event.eventCategory
+                                        .when(EventCategory.EVENT_ONE)
+                                        .then(EventCategory.EVENT_ONE.getMessage())
+                                        .when(EventCategory.EVENT_TWO)
+                                        .then(EventCategory.EVENT_TWO.getMessage())
+                                        .when(EventCategory.EVENT_THREE)
+                                        .then(EventCategory.EVENT_THREE.getMessage())
+                                        .when(EventCategory.EVENT_FOUR)
+                                        .then(EventCategory.EVENT_FOUR.getMessage())
+                                        .when(EventCategory.EVENT_FIVE)
+                                        .then(EventCategory.EVENT_FIVE.getMessage())
+                                        .otherwise("unknown Category")
+                                        .as("categoryMessage")
+                        )
+                )
+                .from(event)
+                .innerJoin(contest)
+                .on(event.eventContest.id.eq(contestId))
+                .where(event.eventContest.id.eq(contestId)
                         .and(event.startTime.after(LocalDateTime.now())
                                 .or(event.endTime.after(LocalDateTime.now())))
-                        )
+                )
                 .fetch();
-
-        return getEventResponseDtos(events);
     }
 
     @Override
-    public List<EventResponseDto> findParticipateEvents(Long contestId, List<EventCategory> eventCategories) {
-        Contest findContest = queryFactory.selectFrom(contest)
-                .where(contest.id.eq(contestId))
-                .fetchFirst();
-        if(findContest == null){
-            throw new ApiException(CONTEST_NOT_FOUND);
-        }
-
-
-        List<Event> events = new ArrayList<>();
-
-        for (EventCategory category : eventCategories) {
-            events.add(queryFactory.selectFrom(event)
-                    .where(event.eventContest.id.eq(findContest.getId())
-                            .and(event.eventCategory.eq(category)))
-                    .fetchFirst());
-        }
-
-        return getEventResponseDtos(events);
+    public List<EventExceptLinksResponseDto> findParticipateEvents(Long participateId) {
+        return queryFactory
+                .select(Projections.constructor(
+                                        EventExceptLinksResponseDto.class,
+                                        event.id,
+                                        event.name,
+                                        event.startTime,
+                                        event.endTime,
+                                        event.location,
+                                        event.building,
+                                        event.speakerName,
+                                        event.major,
+                                        event.eventCondition
+                                                .when(ContestCons.EVENT_PROGRESS)
+                                                .then(ContestCons.EVENT_PROGRESS.getMessage())
+                                                .when(ContestCons.EVENT_BEFORE)
+                                                .then(ContestCons.EVENT_BEFORE.getMessage())
+                                                .when(ContestCons.EVENT_FINISH)
+                                                .then(ContestCons.EVENT_FINISH.getMessage())
+                                                .otherwise("Unknown Condition")
+                                                .as("conditionMessage"),
+                                        event.eventType
+                                                .when(EventType.NO_CHECKING)
+                                                .then(EventType.NO_CHECKING.getMessage())
+                                                .when(EventType.CHECKING)
+                                                .then(EventType.CHECKING.getMessage())
+                                                .otherwise("Unknown Type")
+                                                .as("eventTypeMessage"),
+                                        event.eventCategory
+                                                .when(EventCategory.EVENT_ONE)
+                                                .then(EventCategory.EVENT_ONE.getMessage())
+                                                .when(EventCategory.EVENT_TWO)
+                                                .then(EventCategory.EVENT_TWO.getMessage())
+                                                .when(EventCategory.EVENT_THREE)
+                                                .then(EventCategory.EVENT_THREE.getMessage())
+                                                .when(EventCategory.EVENT_FOUR)
+                                                .then(EventCategory.EVENT_FOUR.getMessage())
+                                                .when(EventCategory.EVENT_FIVE)
+                                                .then(EventCategory.EVENT_FIVE.getMessage())
+                                                .otherwise("unknown Category")
+                                                .as("categoryMessage")
+                                )
+                        )
+                .from(event)
+                .innerJoin(participateContest)
+                .on(event.eventParticipateContest.id.eq(participateId))
+                .fetch();
     }
 
     @Override
@@ -316,5 +389,20 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
                 .entryPreliminaryCounts(adminContestStatsAboutEntryDto.getEntryPreliminaryCounts())
                 .entryFinalCounts(adminContestStatsAboutEntryDto.getEntryFinalCounts())
                 .build();
+    }
+
+    @Override
+    public List<ContestInfoResponseDto> findAllContestInfo(Pageable pageable) {
+        return queryFactory.
+                select(
+                        Projections.constructor(
+                                ContestInfoResponseDto.class,
+                                contest.id.as("contestId"),
+                                contest.name.as("contestName")
+                        )
+                ).from(contest)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
 }

--- a/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/contest/repository/ContestRepositoryCustomImpl.java
@@ -1,10 +1,17 @@
 package sheetplus.checkings.domain.contest.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import sheetplus.checkings.business.page.admin.dto.AdminPageDto.AdminEventStatsDto;
 import sheetplus.checkings.business.page.admin.dto.AdminPageDto.ContestInfoWithCounts;
+import sheetplus.checkings.domain.entry.dto.EntryDto.EntryExceptLinksResponseDto;
+import sheetplus.checkings.domain.enums.ContestCons;
+import sheetplus.checkings.domain.enums.EntryType;
+import sheetplus.checkings.domain.enums.EventType;
+import sheetplus.checkings.domain.event.dto.EventDto.EventExceptLinksResponseDto;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.contest.entity.Contest;
 import sheetplus.checkings.domain.event.entity.Event;
@@ -16,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static sheetplus.checkings.domain.contest.entity.QContest.contest;
+import static sheetplus.checkings.domain.entry.entity.QEntry.entry;
 import static sheetplus.checkings.domain.event.entity.QEvent.event;
 import static sheetplus.checkings.domain.participatecontest.entity.QParticipateContest.participateContest;
 import static sheetplus.checkings.exception.error.ApiError.CONTEST_NOT_FOUND;
@@ -125,5 +133,92 @@ public class ContestRepositoryCustomImpl implements ContestRepositoryCustom{
                         .entryCounts(p.getEntries().size())
                         .build())
                 .toList();
+    }
+
+    @Override
+    public List<EntryExceptLinksResponseDto> findContestWithEntries(Long contestId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(
+                        EntryExceptLinksResponseDto.class,
+                        entry.id.as("id"),
+                        entry.name.as("name"),
+                        entry.location.as("location"),
+                        entry.building.as("building"),
+                        entry.teamNumber.as("teamNumber"),
+                        entry.major.as("major"),
+                        entry.professorName.as("professorName"),
+                        entry.leaderName.as("leaderName"),
+                        entry.entryType
+                                .when(EntryType.PRELIMINARY).then(EntryType.FINALS.getMessage())
+                                .when(EntryType.FINALS).then(EntryType.PRELIMINARY.getMessage())
+                                .otherwise("Unknown Type")
+                                .as("entryType")
+                ))
+                .from(contest)
+                .innerJoin(entry)
+                .on(entry.entryContest.id.eq(contestId))
+                .where(contest.id.eq(contestId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public AdminEventStatsDto findContestWithEvents(Long contestId, Pageable pageable) {
+        List<EventExceptLinksResponseDto> events = queryFactory.select(
+                Projections.constructor(
+                                EventExceptLinksResponseDto.class,
+                                event.id,
+                                event.name,
+                                event.startTime,
+                                event.endTime,
+                                event.location,
+                                event.building,
+                                event.speakerName,
+                                event.major,
+                                event.eventCondition
+                                        .when(ContestCons.EVENT_PROGRESS)
+                                        .then(ContestCons.EVENT_PROGRESS.getMessage())
+                                        .when(ContestCons.EVENT_BEFORE)
+                                        .then(ContestCons.EVENT_BEFORE.getMessage())
+                                        .when(ContestCons.EVENT_FINISH)
+                                        .then(ContestCons.EVENT_FINISH.getMessage())
+                                        .otherwise("Unknown Condition")
+                                        .as("conditionMessage"),
+                                event.eventType
+                                        .when(EventType.NO_CHECKING)
+                                        .then(EventType.NO_CHECKING.getMessage())
+                                        .when(EventType.CHECKING)
+                                        .then(EventType.CHECKING.getMessage())
+                                        .otherwise("Unknown Type")
+                                        .as("eventTypeMessage"),
+                                event.eventCategory
+                                        .when(EventCategory.EVENT_ONE)
+                                        .then(EventCategory.EVENT_ONE.getMessage())
+                                        .when(EventCategory.EVENT_TWO)
+                                        .then(EventCategory.EVENT_TWO.getMessage())
+                                        .when(EventCategory.EVENT_THREE)
+                                        .then(EventCategory.EVENT_THREE.getMessage())
+                                        .when(EventCategory.EVENT_FOUR)
+                                        .then(EventCategory.EVENT_FOUR.getMessage())
+                                        .when(EventCategory.EVENT_FIVE)
+                                        .then(EventCategory.EVENT_FIVE.getMessage())
+                                        .otherwise("unknown Category")
+                                        .as("categoryMessage")
+                        )
+                )
+                .from(contest)
+                .innerJoin(event)
+                .on(event.eventContest.id.eq(contestId))
+                .where(contest.id.eq(contestId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return AdminEventStatsDto
+                .builder()
+                .eventCounts(events.size())
+                .allEvents(events)
+                .build();
     }
 }

--- a/src/main/java/sheetplus/checkings/domain/entry/dto/EntryDto.java
+++ b/src/main/java/sheetplus/checkings/domain/entry/dto/EntryDto.java
@@ -135,5 +135,48 @@ public class EntryDto {
 
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "HATEOAS를 제외한 Entry 응답 Dto", contentMediaType = "application/json")
+    public static class EntryExceptLinksResponseDto{
+        @Schema(description = "Entry PK",
+                example = "1", type = "Long")
+        private Long id;
+
+        @Schema(description = "Entry 이름",
+                example = "name", type = "String")
+        private String name;
+
+        @Schema(description = "Entry 위치",
+                example = "location", type = "String")
+        private String location;
+
+        @Schema(description = "Entry 건물",
+                example = "building", type = "String")
+        private String building;
+
+        @Schema(description = "Entry 팀번호",
+                example = "12", type = "String")
+        private String teamNumber;
+
+        @Schema(description = "Entry 학과",
+                example = "major", type = "String")
+        private String major;
+
+        @Schema(description = "Entry 지도교수명",
+                example = "professor", type = "String")
+        private String professorName;
+
+        @Schema(description = "Entry 리더명",
+                example = "leaderName", type = "String")
+        private String leaderName;
+
+        @Schema(description = "Entry 유형 메세지",
+                example = "본선작", type = "String")
+        private String entryType;
+
+    }
+
 
 }

--- a/src/main/java/sheetplus/checkings/domain/entry/service/EntryCRUDService.java
+++ b/src/main/java/sheetplus/checkings/domain/entry/service/EntryCRUDService.java
@@ -48,15 +48,7 @@ public class EntryCRUDService {
                 .orElseThrow(() -> new ApiException(CONTEST_NOT_FOUND));
         entry.setContestEntry(contest);
         Long entryId = entryRepository.save(entry).getId();
-        List<Link> lists = new ArrayList<>();
-        lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHome(contestId)).withRel("관리자 Home 페이지"));
-        lists.add(linkTo(methodOn(EntryController.class)
-                .updateEntry(entryId, EntryRequestDto.builder().build()))
-                .withRel("작품 UPDATE"));
-        lists.add(linkTo(methodOn(EntryController.class)
-                .deleteEntry(entryId))
-                .withRel("작품 DELETE"));
+
 
 
         return EntryResponseDto.builder()
@@ -69,7 +61,7 @@ public class EntryCRUDService {
                 .leaderName(entry.getLeaderName())
                 .major(entry.getMajor())
                 .entryType(entry.getEntryType().getMessage())
-                .link(lists)
+                .link(hateoasLinks(contestId))
                 .build();
     }
 
@@ -79,18 +71,6 @@ public class EntryCRUDService {
                 .orElseThrow(() -> new ApiException(ENTRY_NOT_FOUND));;
         entry.updateEntry(entryRequestDto);
         Long contestId = entry.getEntryContest().getId();
-
-        List<Link> lists = new ArrayList<>();
-        lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHome(contestId))
-                .withRel("관리자 Home 페이지"));
-        lists.add(linkTo(methodOn(EntryController.class)
-                .createEntry(contestId, EntryRequestDto.builder().build()))
-                .withRel("작품 CREATE"));
-        lists.add(linkTo(methodOn(EntryController.class)
-                .deleteEntry(contestId))
-                .withRel("작품 DELETE"));
-
 
         return EntryResponseDto.builder()
                 .id(id)
@@ -102,8 +82,27 @@ public class EntryCRUDService {
                 .professorName(entry.getProfessorName())
                 .leaderName(entry.getLeaderName())
                 .entryType(entry.getEntryType().getMessage())
-                .link(lists)
+                .link(hateoasLinks(contestId))
                 .build();
+    }
+
+    private List<Link> hateoasLinks(Long contestId) {
+        List<Link> lists = new ArrayList<>();
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeStampStats(contestId)).withRel("관리자 Home 페이지 - 스탬프 통계"));
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeContestStats(contestId)).withRel("관리자 Home 페이지 - Contest 통계"));
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeEventStats(contestId)).withRel("관리자 Home 페이지 - Event 통계"));
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeEntryStats(contestId)).withRel("관리자 Home 페이지 - Entry 통계"));
+        lists.add(linkTo(methodOn(EntryController.class)
+                .createEntry(contestId, EntryRequestDto.builder().build()))
+                .withRel("작품 CREATE"));
+        lists.add(linkTo(methodOn(EntryController.class)
+                .deleteEntry(contestId))
+                .withRel("작품 DELETE"));
+        return lists;
     }
 
     @Transactional

--- a/src/main/java/sheetplus/checkings/domain/entry/service/EntryCRUDService.java
+++ b/src/main/java/sheetplus/checkings/domain/entry/service/EntryCRUDService.java
@@ -93,9 +93,9 @@ public class EntryCRUDService {
         lists.add(linkTo(methodOn(AdminPageController.class)
                 .readAdminHomeContestStats(contestId)).withRel("관리자 Home 페이지 - Contest 통계"));
         lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHomeEventStats(contestId)).withRel("관리자 Home 페이지 - Event 통계"));
+                .readAdminHomeEventStats(contestId,1,1)).withRel("관리자 Home 페이지 - Event 통계"));
         lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHomeEntryStats(contestId)).withRel("관리자 Home 페이지 - Entry 통계"));
+                .readAdminHomeEntryStats(contestId, 1,1)).withRel("관리자 Home 페이지 - Entry 통계"));
         lists.add(linkTo(methodOn(EntryController.class)
                 .createEntry(contestId, EntryRequestDto.builder().build()))
                 .withRel("작품 CREATE"));

--- a/src/main/java/sheetplus/checkings/domain/event/dto/EventDto.java
+++ b/src/main/java/sheetplus/checkings/domain/event/dto/EventDto.java
@@ -140,4 +140,57 @@ public class EventDto {
 
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "HATEOAS를 제외한 Event 응답 DTO", contentMediaType = "application/json")
+    public static class EventExceptLinksResponseDto{
+        @Schema(description = "Event PK",
+                example = "1", type = "Long")
+        private Long id;
+
+        @Schema(description = "Event 이름",
+                example = "eventName", type = "String")
+        private String name;
+
+        @Schema(description = "이벤트 시작시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime startTime;
+
+        @Schema(description = "이벤트 종료시간",
+                example = "2025-01-04 12:09:01", type = "string", pattern = "yyyy-MM-dd HH:mm:ss")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime endTime;
+
+        @Schema(description = "이벤트 장소",
+                example = "location", type = "String")
+        private String location;
+
+        @Schema(description = "이벤트 건물",
+                example = "building", type = "String")
+        private String building;
+
+        @Schema(description = "이벤트 발표자",
+                example = "speakerName", type = "String")
+        private String speakerName;
+
+        @Schema(description = "Member 전공",
+                example = "major", type = "String")
+        private String major;
+
+        @Schema(description = "이벤트 진행상태",
+                example = "EVENT_PROGRESS", type = "String")
+        private String conditionMessage;
+
+        @Schema(description = "이벤트 유형 - 스탬프지급 여부",
+                example = "1", type = "CHECKING")
+        private String eventTypeMessage;
+
+        @Schema(description = "이벤트 분류 - 이벤트 그룹",
+                example = "EVENT_ONE", type = "String")
+        private String categoryMessage;
+
+    }
+
 }

--- a/src/main/java/sheetplus/checkings/domain/event/entity/Event.java
+++ b/src/main/java/sheetplus/checkings/domain/event/entity/Event.java
@@ -9,6 +9,7 @@ import sheetplus.checkings.domain.enums.ContestCons;
 import sheetplus.checkings.domain.enums.EventCategory;
 import sheetplus.checkings.domain.enums.EventType;
 import sheetplus.checkings.domain.eventSending.entity.EventSending;
+import sheetplus.checkings.domain.participatecontest.entity.ParticipateContest;
 
 
 import java.time.LocalDateTime;
@@ -71,10 +72,18 @@ public class Event {
     @Builder.Default
     private List<EventSending> eventSending = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participateContest_id")
+    private ParticipateContest eventParticipateContest;
 
     public void setContestEvent(Contest contest){
         this.eventContest = contest;
         eventContest.getEvents().add(this);
+    }
+
+    public void setEventParticipateContest(ParticipateContest participateContest){
+        this.eventParticipateContest = participateContest;
+        participateContest.getEventParticipateContest().add(this);
     }
 
 

--- a/src/main/java/sheetplus/checkings/domain/event/service/EventCRUDService.java
+++ b/src/main/java/sheetplus/checkings/domain/event/service/EventCRUDService.java
@@ -6,7 +6,8 @@ import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sheetplus.checkings.business.page.admin.controller.AdminPageController;
-import sheetplus.checkings.domain.event.controller.EventController;
+import sheetplus.checkings.domain.entry.controller.EntryController;
+import sheetplus.checkings.domain.entry.dto.EntryDto;
 import sheetplus.checkings.domain.event.dto.EventDto.EventRequestDto;
 import sheetplus.checkings.domain.event.dto.EventDto.EventResponseDto;
 import sheetplus.checkings.domain.contest.entity.Contest;
@@ -64,17 +65,6 @@ public class EventCRUDService {
 
         Long eventId = eventRepository.save(event).getId();
 
-        List<Link> lists = new ArrayList<>();
-        lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHome(contestId))
-                .withRel("관리자 페이지 Home"));
-        lists.add(linkTo(methodOn(EventController.class)
-                .updateEvent(eventId, EventRequestDto.builder().build()))
-                .withRel("이벤트 UPDATE"));
-        lists.add(linkTo(methodOn(EventController.class)
-                .deleteEvent(eventId))
-                .withRel("이벤트 DELETE"));
-
         return EventResponseDto.builder()
                 .id(eventId)
                 .name(event.getName())
@@ -87,7 +77,7 @@ public class EventCRUDService {
                 .categoryMessage(event.getEventCategory().getMessage())
                 .eventTypeMessage(event.getEventType().getMessage())
                 .conditionMessage(event.getEventCondition().getMessage())
-                .link(lists)
+                .link(hateoasLinks(contest.getId()))
                 .build();
     }
 
@@ -117,17 +107,6 @@ public class EventCRUDService {
 
         event.updateEvent(eventRequestDto);
 
-        List<Link> lists = new ArrayList<>();
-        lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHome(contest.getId()))
-                .withRel("관리자 페이지 Home"));
-        lists.add(linkTo(methodOn(EventController.class)
-                .createEvent(contest.getId(), EventRequestDto.builder().build()))
-                .withRel("이벤트 CREATE"));
-        lists.add(linkTo(methodOn(EventController.class)
-                .deleteEvent(eventId))
-                .withRel("이벤트 DELETE"));
-
         return EventResponseDto.builder()
                 .id(event.getId())
                 .name(event.getName())
@@ -140,7 +119,7 @@ public class EventCRUDService {
                 .categoryMessage(event.getEventCategory().getMessage())
                 .eventTypeMessage(event.getEventType().getMessage())
                 .conditionMessage(event.getEventCondition().getMessage())
-                .link(lists)
+                .link(hateoasLinks(contest.getId()))
                 .build();
     }
 
@@ -152,6 +131,25 @@ public class EventCRUDService {
             throw new ApiException(EVENT_NOT_FOUND);
         }
 
+    }
+
+    private List<Link> hateoasLinks(Long contestId) {
+        List<Link> lists = new ArrayList<>();
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeStampStats(contestId)).withRel("관리자 Home 페이지 - 스탬프 통계"));
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeContestStats(contestId)).withRel("관리자 Home 페이지 - Contest 통계"));
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeEventStats(contestId)).withRel("관리자 Home 페이지 - Event 통계"));
+        lists.add(linkTo(methodOn(AdminPageController.class)
+                .readAdminHomeEntryStats(contestId)).withRel("관리자 Home 페이지 - Entry 통계"));
+        lists.add(linkTo(methodOn(EntryController.class)
+                .createEntry(contestId, EntryDto.EntryRequestDto.builder().build()))
+                .withRel("작품 CREATE"));
+        lists.add(linkTo(methodOn(EntryController.class)
+                .deleteEntry(contestId))
+                .withRel("작품 DELETE"));
+        return lists;
     }
 
 

--- a/src/main/java/sheetplus/checkings/domain/event/service/EventCRUDService.java
+++ b/src/main/java/sheetplus/checkings/domain/event/service/EventCRUDService.java
@@ -140,9 +140,9 @@ public class EventCRUDService {
         lists.add(linkTo(methodOn(AdminPageController.class)
                 .readAdminHomeContestStats(contestId)).withRel("관리자 Home 페이지 - Contest 통계"));
         lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHomeEventStats(contestId)).withRel("관리자 Home 페이지 - Event 통계"));
+                .readAdminHomeEventStats(contestId,1,1)).withRel("관리자 Home 페이지 - Event 통계"));
         lists.add(linkTo(methodOn(AdminPageController.class)
-                .readAdminHomeEntryStats(contestId)).withRel("관리자 Home 페이지 - Entry 통계"));
+                .readAdminHomeEntryStats(contestId, 1,1)).withRel("관리자 Home 페이지 - Entry 통계"));
         lists.add(linkTo(methodOn(EntryController.class)
                 .createEntry(contestId, EntryDto.EntryRequestDto.builder().build()))
                 .withRel("작품 CREATE"));

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/dto/ParticipateContestDto.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/dto/ParticipateContestDto.java
@@ -1,6 +1,5 @@
 package sheetplus.checkings.domain.participatecontest.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,13 +13,8 @@ public class ParticipateContestDto {
     @Builder
     @NoArgsConstructor @AllArgsConstructor
     public static class ParticipateInfoResponseDto{
-        @NotNull(message = "응답 데이터 검증 오류: null은 허용하지 않습니다.")
-        private Long completeEventMemberCounts;
-        @NotNull(message = "응답 데이터 검증 오류: null은 허용하지 않습니다.")
         private Long moreThanOneCounts;
-        @NotNull(message = "응답 데이터 검증 오류: null은 허용하지 않습니다.")
         private Long moreThanFiveCounts;
-
     }
 
 }

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/entity/ParticipateContest.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/entity/ParticipateContest.java
@@ -10,10 +10,13 @@ import sheetplus.checkings.domain.contest.entity.Contest;
 import sheetplus.checkings.domain.enums.EventCategory;
 import sheetplus.checkings.domain.enums.MeritType;
 import sheetplus.checkings.domain.enums.ReceiveCons;
+import sheetplus.checkings.domain.event.entity.Event;
 import sheetplus.checkings.domain.member.entity.Member;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -66,6 +69,10 @@ public class ParticipateContest {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private Set<EventCategory> eventTypeSet = new HashSet<>();
+
+    @OneToMany(mappedBy = "eventParticipateContest")
+    @Builder.Default
+    private List<Event> eventParticipateContest = new ArrayList<>();
 
 
     public void setMemberParticipateContestStates(Member member){

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
@@ -46,7 +46,8 @@ public class ParticipateContestStateRepositoryCustomImpl implements ParticipateC
                                         .otherwise(0L).as("moreThanFiveCounts")
                         )
                 ).from(participateContest)
-                .fetchOne();
+                .where(participateContest.contestParticipateContestState.id.eq(id))
+                .fetchFirst();
     }
 
 

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package sheetplus.checkings.domain.participatecontest.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,22 +33,20 @@ public class ParticipateContestStateRepositoryCustomImpl implements ParticipateC
 
     @Override
     public ParticipateInfoResponseDto participateContestCounts(Long id) {
-        Long countOne = queryFactory
-                .select(participateContest.count())
-                .from(participateContest)
-                .where(participateContest.eventsCount.goe(1))
+        return queryFactory
+                .select(
+                        Projections.fields(ParticipateInfoResponseDto.class,
+                                new CaseBuilder()
+                                        .when(participateContest.eventsCount.goe(1))
+                                        .then(participateContest.count())
+                                        .otherwise(0L).as("moreThanOneCounts"),
+                                new CaseBuilder()
+                                        .when(participateContest.eventsCount.goe(5))
+                                        .then(participateContest.count())
+                                        .otherwise(0L).as("moreThanFiveCounts")
+                        )
+                ).from(participateContest)
                 .fetchOne();
-        Long countAll = queryFactory
-                .select(participateContest.count())
-                .from(participateContest)
-                .where(participateContest.eventsCount.goe(5))
-                .fetchOne();
-
-        return ParticipateInfoResponseDto.builder()
-                .completeEventMemberCounts(countAll)
-                .moreThanOneCounts(countOne)
-                .moreThanFiveCounts(countAll)
-                .build();
     }
 
 

--- a/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
+++ b/src/main/java/sheetplus/checkings/domain/participatecontest/repository/ParticipateContestStateRepositoryCustomImpl.java
@@ -35,7 +35,7 @@ public class ParticipateContestStateRepositoryCustomImpl implements ParticipateC
     public ParticipateInfoResponseDto participateContestCounts(Long id) {
         return queryFactory
                 .select(
-                        Projections.fields(ParticipateInfoResponseDto.class,
+                        Projections.constructor(ParticipateInfoResponseDto.class,
                                 new CaseBuilder()
                                         .when(participateContest.eventsCount.goe(1))
                                         .then(participateContest.count())

--- a/src/main/java/sheetplus/checkings/exception/error/ApiError.java
+++ b/src/main/java/sheetplus/checkings/exception/error/ApiError.java
@@ -38,7 +38,8 @@ public enum ApiError implements ErrorCodeIfs {
     EXPIRED_QR_CODES(HttpStatus.UNAUTHORIZED, "이미 만료된 QR코드 요청입니다."),
     ROLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없는 사용자입니다."),
     HTTP_INPUT_NOT_READABLE(HttpStatus.BAD_REQUEST, "잘못된 HTTP 입력 요청"),
-    SUBSCRIBE_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 상태정보를 찾을 수 없습니다.")
+    SUBSCRIBE_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 상태정보를 찾을 수 없습니다."),
+    QR_EXPIRED_TIME_NOT_VALID(HttpStatus.BAD_REQUEST, "QR코드 만료시간 복호화에 실패했습니다. 암호화한 날짜 데이터를 확인해주세요")
     ;
 
 


### PR DESCRIPTION
- [x] QRcode 암호화 방식 변경
- [x] 쿼리 횟수 축소를 위한 Querydsl 적용 및 최적화
- [x] 페이지에 의존하는 API 분리 (Admin/Student Home page)
- [x]  다수 데이터 GET API 페이징 기능 추가
- [X] 학생 페이지 건물별로 조회하는 기능 추가
- [x] ERD 연관관계 추가 (ParticipateContest-Event / 1:N)

##  QRcode 암호화 방식 변경 세부
- QRcode 만료시간을 FE에서 암호화하기 위해 암호키를 주던 방식에서 , BE가 직접 암호화한 만료시간을 주는 방식으로 변경
- 사유: 성능보다 보안이 더 중요하다고 판단했기 때문. (성능은 개선할 방법이 있지만 보안은 유출될경우 피해가 큽니다)
- FE는 Polling 방식으로 15초마다 갱신하는 요청을 전달해야함

## 페이지에 의존하는 API 분리
- Home Page의 경우, 각 공통 기능별로 API를 분리함
사유: 성능 개선, 일부 데이터 조회 실패 시 전체 데이터에 영향 미치는 문제 해결하기 위함
### Admin
- 4개로 분리함 (스탬프/Contest/Event,Entry 통계 데이터)
### Student
- 2개로 분리함(MemberInfoAndParticipateInfo, TodaysEvent)

## 학생 페이지 건물별로 조회하는 기능 추가
학생 Home 페이지의 오늘 참여할 수 있는 이벤트 GET API에 파라미터로 탐색할 건물을 포함할 수 있음.

## 페이징 관련
- 최소 값은 모두 1입니다. 음수값이나 0값으로 요청하지 마세요